### PR TITLE
Centralize buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,28 @@
 
 # 🤖 droid.nvim
 
-**Complete Android development workflow for Neovim**
+**Android development workflow for Neovim**
 
 [![Neovim](https://img.shields.io/badge/Neovim-0.10+-green.svg?style=flat-square&logo=neovim)](https://neovim.io)
 [![Lua](https://img.shields.io/badge/Made%20with-Lua-blue.svg?style=flat-square&logo=lua)](https://lua.org)
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
-Build, run, and debug Android apps directly from Neovim with real-time logcat filtering.
-
-> **⚠️ Note:** This repository is currently under heavy maintenance. Some features may be unstable or subject to breaking changes.
+Build, run, and debug Android apps directly from Neovim.
 
 </div>
 
 ## ✨ Features
 
-- 🔧 **Gradle Integration** - Build, clean, sync, and run custom tasks with automatic `gradlew` detection
-- 📱 **Smart Device Management** - Auto-detect devices/emulators with interactive selection
-- 📋 **Advanced Logcat** - Real-time filtering by package, tag, log level, and regex patterns
-- 🚀 **One-Command Workflow** - Build → Install → Launch → Logcat in a single `:DroidRun`
-- ⚙️ **Flexible Display** - Horizontal, vertical, or floating logcat windows
-- 🎯 **Smart Session Management** - Automatic logcat reuse and efficient process cleanup
-- 🔄 **Progress Indicators** - Visual feedback for long-running operations
-- 🏗️ **Modular Architecture** - Composable actions for custom workflows
+- 🚀 **One-Command Workflow** - Build → Install → Launch → Logcat with `:DroidRun`
+- 📱 **Smart Device Management** - Auto-detect devices/emulators
+- 📋 **Real-time Logcat** - Filter by package, tag, log level, and patterns
+- 🔧 **Gradle Integration** - Build, clean, sync with automatic `gradlew` detection
+- ⚙️ **Flexible Windows** - Horizontal, vertical, or floating displays
+- 🎯 **Simple Configuration** - Minimal setup required
 
 ## 📦 Installation
 
-**Requirements:** Neovim 0.10+, Android SDK, project with `gradlew`
+**Requirements:** Neovim 0.10+, Android SDK with `adb` in PATH
 
 ```lua
 -- lazy.nvim
@@ -39,197 +35,129 @@ Build, run, and debug Android apps directly from Neovim with real-time logcat fi
 }
 ```
 
-**Configuration (optional):**
+**Optional Configuration:**
 
 ```lua
 require("droid").setup({
   logcat = {
-    window_type = "horizontal", -- "horizontal" | "vertical" | "float"
-    height = 12,
-    width = 80,
+    mode = "horizontal", -- "horizontal" | "vertical" | "float"
+    height = 15,
     filters = {
-      package = "mine", -- "mine" (auto-detect), specific package, or "none"
-      log_level = "v", -- v, d, i, w, e, f
-      tag = nil, -- specific tag or nil
-      grep_pattern = nil, -- regex pattern or nil
+      package = "mine", -- "mine" (auto-detect) or specific package
+      log_level = "d", -- v, d, i, w, e, f
     },
   },
   android = {
-    auto_select_single_target = true, -- Auto-select if only one device
-    auto_launch_app = true, -- Auto-launch after install
-    device_wait_timeout_ms = 30000, -- Device wait timeout
-    logcat_startup_delay_ms = 2000, -- Delay before logcat starts
-    qt_qpa_platform = nil, -- Qt platform for emulator (Linux: "xcb")
+    auto_launch_app = true, -- Launch app after install
+    qt_qpa_platform = "xcb", -- Linux: "xcb" or "wayland"
   },
 })
 ```
 
 ## 🚀 Usage
 
-### Core Commands
+### Essential Commands
 
-| Command            | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `:DroidRun`        | **Complete workflow:** Build → Install → Launch → Logcat |
-| `:DroidBuildDebug` | Build debug APK only                                     |
-| `:DroidLogcat`     | Open logcat viewer (device selection if needed)          |
-| `:DroidLogcatStop` | Stop logcat and close window                             |
+| Command            | Description                           |
+| ------------------ | ------------------------------------- |
+| `:DroidRun`        | Build → Install → Launch → Logcat    |
+| `:DroidLogcat`     | Show logcat for selected device      |
+| `:DroidBuildDebug` | Build debug APK only                 |
+| `:DroidInstall`    | Install APK without launching        |
+| `:DroidDevices`    | Show available devices/emulators     |
+| `:DroidEmulator`   | Start emulator from AVD list         |
 
 ### Gradle Commands
 
-| Command             | Description                                  |
-| ------------------- | -------------------------------------------- |
-| `:DroidClean`       | Clean project (`./gradlew clean`)            |
-| `:DroidSync`        | Sync dependencies (`--refresh-dependencies`) |
-| `:DroidTask <task>` | Run custom Gradle task with args             |
-| `:DroidInstall`     | Install APK without launching                |
+| Command             | Description                     |
+| ------------------- | ------------------------------- |
+| `:DroidClean`       | Clean project                  |
+| `:DroidSync`        | Sync dependencies              |
+| `:DroidTask <task>` | Run custom Gradle task         |
 
-### Device & Emulator Management
+### Logcat Filtering
 
-| Command                  | Description                  |
-| ------------------------ | ---------------------------- |
-| `:DroidDevices`          | Show device selection dialog |
-| `:DroidEmulator`         | Launch emulator (AVD picker) |
-| `:DroidEmulatorStop`     | Stop running emulator        |
-| `:DroidEmulatorWipeData` | Wipe emulator data           |
-| `:DroidStartEmulator`    | Start emulator workflow      |
+| Command                                | Description                      |
+| -------------------------------------- | -------------------------------- |
+| `:DroidLogcatFilter log_level=d`      | Show debug level and above       |
+| `:DroidLogcatFilter tag=MyTag`        | Filter by specific tag           |
+| `:DroidLogcatFilter package=mine`     | Show only your app's logs        |
+| `:DroidLogcatFilter grep=Exception`   | Filter by text pattern           |
 
-### Advanced Logcat Features
-
-| Command                                | Description                                       |
-| -------------------------------------- | ------------------------------------------------- |
-| `:DroidLogcatFilter log_level=<level>` | Filter by log level: `v`, `d`, `i`, `w`, `e`, `f` |
-| `:DroidLogcatFilter tag=<name>`        | Filter by specific tag                            |
-| `:DroidLogcatFilter package=<name>`    | Filter by package (`mine` = auto-detect)          |
-| `:DroidLogcatFilter grep=<pattern>`    | Filter by regex pattern                           |
-| `:DroidLogcatFilterShow`               | Show currently active filters                     |
-| `:DroidLogcatToggleAutoScroll`         | Toggle auto-scroll to bottom                      |
-
-**Combine filters:** `:DroidLogcatFilter tag=MyTag log_level=d package=mine`
-
-### Smart Logcat Behavior
-
-- **Session Reuse**: Running `:DroidRun` twice preserves logcat history
-- **Filter Changes**: New filters restart logcat (previous content lost)
-- **Device Changes**: Switching devices restarts logcat
-- **Window Management**: Logcat windows reopen automatically when needed
+**Combine filters:** `:DroidLogcatFilter tag=MyTag log_level=d`
 
 ### Quick Setup
 
 ```lua
 -- Recommended keybindings
 vim.keymap.set("n", "<leader>ar", ":DroidRun<CR>", { desc = "Run Android app" })
-vim.keymap.set("n", "<leader>ab", ":DroidBuildDebug<CR>", { desc = "Build debug APK" })
 vim.keymap.set("n", "<leader>al", ":DroidLogcat<CR>", { desc = "Open logcat" })
-vim.keymap.set("n", "<leader>ax", ":DroidLogcatStop<CR>", { desc = "Stop logcat" })
+vim.keymap.set("n", "<leader>ab", ":DroidBuildDebug<CR>", { desc = "Build debug APK" })
 vim.keymap.set("n", "<leader>ae", ":DroidEmulator<CR>", { desc = "Launch emulator" })
-vim.keymap.set("n", "<leader>ad", ":DroidDevices<CR>", { desc = "Show devices" })
 ```
 
-### Typical Development Workflow
+### Typical Workflow
 
-1. **`:DroidRun`** - Complete workflow: build, install, launch with logcat
-2. **`:DroidLogcatFilter log_level=e`** - Filter to show only errors
-3. **`:DroidLogcatFilter tag=MyActivity`** - Focus on specific component
-4. **`:DroidLogcatFilter package=mine grep=API`** - Your app's API calls only
-5. **`:DroidRun`** - Run again (reuses logcat, preserves history)
-6. **`:DroidLogcatStop`** - Stop when done
+1. **`:DroidRun`** - Build, install, launch, and show logcat
+2. **`:DroidLogcatFilter package=mine log_level=d`** - Focus on your app
+3. **`:DroidLogcatFilter tag=MyActivity`** - Filter specific components
+4. Make code changes and repeat
 
-### Real-World Examples
+### Examples
 
 ```vim
-" Development commands
-:DroidTask assembleRelease           " Build release APK
-:DroidTask testDebugUnitTest         " Run unit tests
-:DroidTask connectedAndroidTest      " Run instrumented tests
-:DroidTask bundleRelease             " Build app bundle
+" Build and test
+:DroidRun                            " Full workflow
+:DroidTask assembleRelease           " Build release
+:DroidTask testDebugUnitTest         " Run tests
 
-" Logcat filtering examples
-:DroidLogcatFilter package=mine log_level=d    " Your app, debug level+
-:DroidLogcatFilter tag=NetworkManager          " Focus on network logs
-:DroidLogcatFilter grep=Exception               " Show only exceptions
-:DroidLogcatFilter log_level=e package=none    " All errors, all apps
-
-" Device management
-:DroidEmulator                       " Launch emulator with AVD picker
-:DroidEmulatorWipeData              " Clean emulator for fresh testing
-:DroidDevices                       " See available devices
+" Logcat filtering
+:DroidLogcatFilter package=mine      " Show only your app
+:DroidLogcatFilter log_level=e       " Errors only
+:DroidLogcatFilter grep=Exception    " Find exceptions
 ```
 
-### Power User Tips
+## 🔧 Setup
 
-- Use `:DroidLogcatFilterShow` to see active filters
-- Logcat auto-scrolls by default, toggle with `:DroidLogcatToggleAutoScroll`
-- Package `mine` automatically detects your project's package name
-- Combine multiple filters for precise debugging
-- Window reopens automatically if closed while logcat runs
+### Android SDK
 
-## 🔧 Environment Setup
+The plugin auto-detects your Android SDK from:
+- `ANDROID_SDK_ROOT` or `ANDROID_HOME` environment variables
+- `vim.g.android_sdk` (manual override)
+- Platform defaults (`~/Library/Android/sdk`, `/opt/android-sdk`, etc.)
 
-### Android SDK Configuration
+### Project Requirements
 
-The plugin automatically detects your Android SDK from these locations (in order):
+1. Executable `gradlew` in project root: `chmod +x gradlew`
+2. Android SDK with `adb` in PATH
+3. Connected device or running emulator
 
-1. `vim.g.android_sdk` (Neovim variable)
-2. `ANDROID_SDK_ROOT` environment variable
-3. `ANDROID_HOME` environment variable
-4. Platform-specific defaults:
-   - **Linux**: `/opt/android-sdk`, `/usr/lib/android-sdk`
-   - **macOS**: `~/Library/Android/sdk`, `/usr/local/lib/android/sdk`
-   - **Windows**: `%LOCALAPPDATA%/Android/Sdk`, `%PROGRAMFILES%/Android/Android Studio/sdk`
+### Linux Users
 
-**Manual override:**
-
-```lua
-vim.g.android_sdk = "/path/to/android-sdk"
-```
-
-### Project Setup
-
-1. **Make gradlew executable**: `chmod +x gradlew`
-2. **Ensure ADB access**: `adb devices` should list your devices
-3. **Test emulator**: `emulator -list-avds` should show available AVDs
-
-### Linux-Specific Setup
-
-For emulator compatibility on Linux:
+Set Qt platform for emulator compatibility:
 
 ```lua
 require("droid").setup({
-  android = {
-    qt_qpa_platform = "xcb",  -- or "wayland", "offscreen"
-  },
+  android = { qt_qpa_platform = "xcb" },
 })
 ```
 
 ## 🛠️ Troubleshooting
 
-### Common Issues
+| Issue                     | Solution                                 |
+| ------------------------- | ---------------------------------------- |
+| **"gradlew not found"**   | Run `chmod +x gradlew` in project root   |
+| **"Android SDK not found"** | Set `ANDROID_SDK_ROOT` environment variable |
+| **"No devices available"** | Connect device or start emulator        |
+| **Emulator won't start (Linux)** | Set `qt_qpa_platform = "xcb"` in config |
 
-| Issue                       | Solution                                                     |
-| --------------------------- | ------------------------------------------------------------ |
-| **"gradlew not found"**     | Run `chmod +x gradlew` in project root                       |
-| **"Android SDK not found"** | Set `ANDROID_SDK_ROOT`/`ANDROID_HOME` or `vim.g.android_sdk` |
-| **"No devices available"**  | Check `adb devices`, ensure devices/emulators are connected  |
-| **"Emulator won't start"**  | Set `qt_qpa_platform = "xcb"` in config (Linux)              |
-| **"Package not found"**     | Ensure `applicationId` is in `android/app/build.gradle`      |
-| **Logcat not filtering**    | Check filters with `:DroidLogcatFilterShow`                  |
-
-### Debugging Commands
+### Debug Commands
 
 ```vim
-:messages                           " Check for plugin errors
-:lua print(vim.inspect(require("droid.config").config))  " Show current config
-:lua print(require("droid.android").get_adb_path())      " Check ADB path
-:DroidTask tasks                    " List available Gradle tasks
+:messages                    " Check for errors
+:DroidTask tasks            " List Gradle tasks
+:lua print(require("droid.android").get_adb_path())  " Check ADB path
 ```
-
-### Performance Tips
-
-- Use specific package filters to reduce logcat noise
-- Close logcat windows when not needed to free resources
-- Use `:DroidLogcatStop` instead of just closing windows
-- Restart logcat if it becomes unresponsive
 
 ---
 

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -1,5 +1,5 @@
 -- High-level workflow actions for droid.nvim
--- This module provides reusable, independent functions for common Android development tasks
+-- Simplified, reusable functions for common Android development tasks
 
 local config = require "droid.config"
 local gradle = require "droid.gradle"
@@ -9,54 +9,61 @@ local progress = require "droid.progress"
 
 local M = {}
 
--- Validates and gets required tools (adb, emulator)
--- Returns: { adb = path, emulator = path } or nil if validation fails
+-- Helper function to handle common post-install workflow
+local function handle_post_install(tools, device_id, session_id, launch_app)
+    local cfg = config.get()
+
+    local function start_logcat()
+        local delay_ms = cfg.android.logcat_startup_delay_ms or 2000
+        vim.defer_fn(function()
+            logcat.refresh_logcat(tools.adb, device_id, nil, {})
+            local message = launch_app and "Build, install, and launch completed" or "Build and install completed"
+            progress.stop_loading(session_id, true, message)
+        end, delay_ms)
+    end
+
+    if launch_app and cfg.android.auto_launch_app then
+        android.launch_app_on_device(tools.adb, device_id, start_logcat)
+    else
+        start_logcat()
+    end
+end
+
+-- Helper function to execute build and install workflow
+local function execute_build_install(tools, device_id, session_id, launch_app)
+    gradle.build_and_install_debug(function(success, exit_code, message, step)
+        if not success then
+            local error_msg = string.format("Workflow failed at %s step: %s", step, message)
+            progress.stop_loading(session_id, false, error_msg)
+            return
+        end
+
+        handle_post_install(tools, device_id, session_id, launch_app)
+    end)
+end
+
+-- Get required Android tools or show error
 function M.get_required_tools()
     local adb = android.get_adb_path()
     local emulator = android.get_emulator_path()
 
     if not adb or not emulator then
+        vim.notify("Android SDK tools not found. Check ANDROID_SDK_ROOT.", vim.log.levels.ERROR)
         return nil
     end
 
     return { adb = adb, emulator = emulator }
 end
 
--- Executes target selection workflow
--- Args: tools (from get_required_tools), callback(target)
--- Target: { type = "device"|"avd", id = device_id, name = display_name, avd = avd_name }
+-- Select target device or emulator
 function M.select_target(tools, callback)
     if not tools then
-        vim.notify("Android tools not available", vim.log.levels.ERROR)
         return
     end
-
     android.choose_target(tools.adb, tools.emulator, callback)
 end
 
--- Builds debug APK only
--- Args: callback() - called after build completes
-function M.build_debug(callback)
-    gradle.build_debug()
-    if callback then
-        vim.schedule(callback)
-    end
-end
-
--- Installs debug APK only (no launch)
--- Args: adb, device_id, callback() - called after install completes
-function M.install_debug(callback)
-    gradle.install_debug(callback)
-end
-
--- Installs and launches debug APK
--- Args: adb, device_id, callback() - called after launch completes
-function M.install_and_launch(adb, device_id, callback)
-    gradle.install_debug_and_launch(adb, device_id, callback)
-end
-
--- Complete build and run workflow (the core DroidRun functionality)
--- This is the main workflow: select target -> install+launch -> logcat
+-- Complete build and run workflow (core DroidRun functionality)
 function M.build_and_run()
     local tools = M.get_required_tools()
     if not tools then
@@ -68,45 +75,26 @@ function M.build_and_run()
             return
         end
 
-        -- Start loading after device selection
         local session_id = progress.start_loading {
             command = "DroidRun",
             priority = progress.PRIORITY.CRITICAL,
-            message = "Running build and install application",
+            message = "Building and installing application",
         }
 
         if not session_id then
-            return -- Loading was queued or cancelled
+            return
         end
 
         if target.type == "device" then
-            M.install_and_launch(tools.adb, target.id, function()
-                -- Add delay before starting logcat to let app fully start
-                local cfg = config.get()
-                local delay_ms = cfg.logcat_startup_delay_ms or 2000
-
-                vim.defer_fn(function()
-                    logcat.refresh_logcat(tools.adb, target.id, nil, {})
-                    progress.stop_loading(session_id, true, "Run application successful")
-                end, delay_ms)
-            end)
+            execute_build_install(tools, target.id, session_id, true)
         elseif target.type == "avd" then
             android.start_emulator(tools.emulator, target.avd)
             android.wait_for_device_id(tools.adb, function(device_id)
-                if device_id then
-                    M.install_and_launch(tools.adb, device_id, function()
-                        -- Add delay before starting logcat to let app fully start
-                        local cfg = config.get()
-                        local delay_ms = cfg.logcat_startup_delay_ms or 2000
-
-                        vim.defer_fn(function()
-                            logcat.refresh_logcat(tools.adb, device_id, nil, {})
-                            progress.stop_loading(session_id, true, "Run application successful")
-                        end, delay_ms)
-                    end)
-                else
-                    progress.stop_loading(session_id, false, "Failed to start emulator or device not ready")
+                if not device_id then
+                    progress.stop_loading(session_id, false, "Failed to start emulator")
+                    return
                 end
+                execute_build_install(tools, device_id, session_id, true)
             end)
         end
     end)
@@ -119,15 +107,14 @@ function M.install_only()
         return
     end
 
-    -- Start loading with global management
     local session_id = progress.start_loading {
         command = "DroidInstall",
         priority = progress.PRIORITY.CRITICAL,
-        message = "Selecting target device",
+        message = "Installing application",
     }
 
     if not session_id then
-        return -- Loading was queued or cancelled
+        return
     end
 
     M.select_target(tools, function(target)
@@ -137,39 +124,36 @@ function M.install_only()
         end
 
         if target.type == "device" then
-            progress.update_spinner_message("Installing on " .. target.name)
-            M.install_debug(function()
-                progress.stop_loading(session_id, true, "Installation completed")
-            end)
+            execute_build_install(tools, target.id, session_id, false)
         elseif target.type == "avd" then
-            progress.update_spinner_message "Starting emulator"
             android.start_emulator(tools.emulator, target.avd)
             android.wait_for_device_id(tools.adb, function(device_id)
-                if device_id then
-                    progress.update_spinner_message "Installing on emulator"
-                    M.install_debug(function()
-                        progress.stop_loading(session_id, true, "Installation completed")
-                    end)
-                else
-                    progress.stop_loading(session_id, false, "Failed to start emulator or device not ready")
+                if not device_id then
+                    progress.stop_loading(session_id, false, "Failed to start emulator")
+                    return
                 end
+                execute_build_install(tools, device_id, session_id, false)
             end)
         end
     end)
 end
 
--- Logcat-only workflow
+-- Install and launch workflow (for backward compatibility)
+function M.install_and_launch()
+    M.build_and_run()
+end
+
+-- Show logcat for selected device
 function M.logcat_only()
     local tools = M.get_required_tools()
     if not tools then
         return
     end
 
-    -- Directly use logcat's device selection (which now only shows running devices)
     logcat.apply_filters {}
 end
 
--- Device selection workflow (just shows selected device)
+-- Show device selection dialog
 function M.show_devices()
     local tools = M.get_required_tools()
     if not tools then
@@ -177,15 +161,18 @@ function M.show_devices()
     end
 
     M.select_target(tools, function(target)
-        if target.type == "device" then
-            vim.notify("Selected device: " .. target.name .. " (" .. target.id .. ")", vim.log.levels.INFO)
-        elseif target.type == "avd" then
-            vim.notify("Selected AVD: " .. target.name .. " (" .. target.avd .. ")", vim.log.levels.INFO)
+        if not target then
+            return
         end
+
+        local msg = target.type == "device" and string.format("Selected device: %s (%s)", target.name, target.id)
+            or string.format("Selected AVD: %s (%s)", target.name, target.avd)
+
+        vim.notify(msg, vim.log.levels.INFO)
     end)
 end
 
--- Start emulator workflow
+-- Start emulator from AVD list
 function M.start_emulator()
     local tools = M.get_required_tools()
     if not tools then
@@ -193,6 +180,10 @@ function M.start_emulator()
     end
 
     M.select_target(tools, function(target)
+        if not target then
+            return
+        end
+
         if target.type == "avd" then
             android.start_emulator(tools.emulator, target.avd)
         else

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -16,7 +16,7 @@ local function handle_post_install(tools, device_id, session_id, launch_app)
     local function start_logcat()
         local delay_ms = cfg.android.logcat_startup_delay_ms or 2000
         vim.defer_fn(function()
-            logcat.refresh_logcat(tools.adb, device_id, nil, {})
+            logcat.refresh_logcat(tools.adb, device_id, nil, nil)
             local message = launch_app and "Build, install, and launch completed" or "Build and install completed"
             progress.stop_loading(session_id, true, message)
         end, delay_ms)
@@ -89,9 +89,9 @@ function M.build_and_run()
             execute_build_install(tools, target.id, session_id, true)
         elseif target.type == "avd" then
             android.start_emulator(tools.emulator, target.avd)
-            android.wait_for_device_id(tools.adb, function(device_id)
+            android.wait_for_device_ready(tools.adb, function(device_id)
                 if not device_id then
-                    progress.stop_loading(session_id, false, "Failed to start emulator")
+                    progress.stop_loading(session_id, false, "Failed to start emulator or device not ready")
                     return
                 end
                 execute_build_install(tools, device_id, session_id, true)
@@ -127,9 +127,9 @@ function M.install_only()
             execute_build_install(tools, target.id, session_id, false)
         elseif target.type == "avd" then
             android.start_emulator(tools.emulator, target.avd)
-            android.wait_for_device_id(tools.adb, function(device_id)
+            android.wait_for_device_ready(tools.adb, function(device_id)
                 if not device_id then
-                    progress.stop_loading(session_id, false, "Failed to start emulator")
+                    progress.stop_loading(session_id, false, "Failed to start emulator or device not ready")
                     return
                 end
                 execute_build_install(tools, device_id, session_id, false)

--- a/lua/droid/buffer.lua
+++ b/lua/droid/buffer.lua
@@ -1,0 +1,279 @@
+-- Simple buffer management for droid.nvim
+-- Manages a single reusable buffer for both logcat and gradle output
+
+local config = require "droid.config"
+
+local M = {}
+
+-- Simple state tracking
+M.buffer_id = nil
+M.window_id = nil
+M.buffer_type = nil -- "logcat" | "gradle"
+M.current_job_id = nil
+
+-- Check if buffer is busy with a different type
+local function is_buffer_busy(new_type)
+    return M.buffer_id and vim.api.nvim_buf_is_valid(M.buffer_id) and M.buffer_type ~= new_type
+end
+
+-- Get or create buffer for specified type and mode
+local function get_or_create_buffer(buffer_type, mode)
+    -- Check if buffer was deleted externally
+    if M.buffer_id and not vim.api.nvim_buf_is_valid(M.buffer_id) then
+        M.reset_state()
+    end
+
+    -- Create new buffer if needed
+    if not M.buffer_id then
+        M.buffer_id = vim.api.nvim_create_buf(false, true)
+        M.buffer_type = buffer_type
+        M.setup_buffer(buffer_type)
+        M.open_window(mode)
+        M.attach_cleanup()
+    else
+        -- Reuse existing buffer
+        if M.buffer_type ~= buffer_type then
+            M.stop_current_job()
+            M.buffer_type = buffer_type
+            M.setup_buffer(buffer_type)
+        end
+
+        M.clear_content()
+
+        -- Ensure window is visible
+        if not M.window_id or not vim.api.nvim_win_is_valid(M.window_id) then
+            M.open_window(mode)
+        end
+    end
+
+    return M.buffer_id, M.window_id
+end
+
+-- Get or create buffer for specified type and mode
+-- Args: type ("logcat" | "gradle"), mode (window display mode)
+-- Returns: buffer_id, window_id
+function M.get_or_create(buffer_type, mode)
+    -- Warn if switching buffer types while in use
+    if is_buffer_busy(buffer_type) then
+        vim.notify(string.format("Switching buffer from %s to %s", M.buffer_type, buffer_type), vim.log.levels.INFO)
+    end
+
+    return get_or_create_buffer(buffer_type, mode)
+end
+
+-- Clear buffer content and prepare for new output
+function M.clear_content()
+    if M.buffer_id and vim.api.nvim_buf_is_valid(M.buffer_id) then
+        -- Make buffer modifiable temporarily
+        local was_modifiable = vim.bo[M.buffer_id].modifiable
+        vim.bo[M.buffer_id].modifiable = true
+
+        -- Clear all content
+        vim.api.nvim_buf_set_lines(M.buffer_id, 0, -1, false, {})
+
+        -- Reset modified flag
+        vim.bo[M.buffer_id].modified = false
+
+        -- Restore modifiable state
+        vim.bo[M.buffer_id].modifiable = was_modifiable
+    end
+end
+
+-- Switch buffer content type (logcat ↔ gradle)
+function M.switch_content(new_type)
+    if M.buffer_id and vim.api.nvim_buf_is_valid(M.buffer_id) then
+        M.stop_current_job()
+        M.buffer_type = new_type
+        M.setup_buffer(new_type)
+        M.clear_content()
+    end
+end
+
+-- Reset buffer state (for when buffer becomes invalid)
+function M.reset_state()
+    M.buffer_id = nil
+    M.window_id = nil
+    M.buffer_type = nil
+    M.current_job_id = nil
+end
+
+-- Setup buffer properties based on type
+function M.setup_buffer(type)
+    if not M.buffer_id or not vim.api.nvim_buf_is_valid(M.buffer_id) then
+        return
+    end
+
+    if type == "logcat" then
+        vim.bo[M.buffer_id].filetype = "logcat"
+        vim.bo[M.buffer_id].modifiable = false
+        vim.bo[M.buffer_id].readonly = true
+    elseif type == "gradle" then
+        vim.bo[M.buffer_id].filetype = "terminal"
+        vim.bo[M.buffer_id].modifiable = true
+        vim.bo[M.buffer_id].readonly = false
+    end
+
+    -- Common buffer settings
+    vim.bo[M.buffer_id].buflisted = false
+    vim.bo[M.buffer_id].bufhidden = "wipe"
+end
+
+-- Open window according to display mode
+function M.open_window(mode)
+    if not M.buffer_id or not vim.api.nvim_buf_is_valid(M.buffer_id) then
+        return false
+    end
+
+    local cfg = config.get()
+    mode = mode or cfg.logcat.mode
+
+    -- Close existing window if open
+    if M.window_id and vim.api.nvim_win_is_valid(M.window_id) then
+        vim.api.nvim_win_close(M.window_id, true)
+    end
+
+    -- Open window according to mode
+    if mode == "horizontal" then
+        local height = cfg.logcat.height or 15
+        vim.cmd("botright split | resize " .. height)
+        M.window_id = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(M.window_id, M.buffer_id)
+    elseif mode == "vertical" then
+        local width = cfg.logcat.width or 80
+        vim.cmd("vsplit | vertical resize " .. width)
+        M.window_id = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(M.window_id, M.buffer_id)
+    elseif mode == "float" then
+        local win_opts = {
+            relative = "editor",
+            width = cfg.logcat.float_width or 120,
+            height = cfg.logcat.float_height or 30,
+            row = (vim.o.lines - (cfg.logcat.float_height or 30)) / 2,
+            col = (vim.o.columns - (cfg.logcat.float_width or 120)) / 2,
+            style = "minimal",
+            border = "rounded",
+        }
+        M.window_id = vim.api.nvim_open_win(M.buffer_id, true, win_opts)
+    end
+
+    return M.window_id ~= nil
+end
+
+-- Attach cleanup handlers
+function M.attach_cleanup()
+    if not M.buffer_id then
+        return
+    end
+
+    -- Handle buffer deletion
+    vim.api.nvim_create_autocmd("BufWipeout", {
+        buffer = M.buffer_id,
+        once = true,
+        callback = function()
+            M.close()
+        end,
+    })
+
+    -- Handle Neovim exit
+    vim.api.nvim_create_autocmd("VimLeavePre", {
+        callback = function()
+            M.close()
+        end,
+        once = true,
+    })
+end
+
+-- Stop current running job
+function M.stop_current_job()
+    if M.current_job_id then
+        vim.fn.jobstop(M.current_job_id)
+        M.current_job_id = nil
+    end
+end
+
+-- Close buffer and reset state
+function M.close()
+    -- Stop any running job
+    M.stop_current_job()
+
+    -- Close window
+    if M.window_id and vim.api.nvim_win_is_valid(M.window_id) then
+        vim.api.nvim_win_close(M.window_id, true)
+    end
+
+    -- Delete buffer (with error handling for terminal buffers)
+    if M.buffer_id and vim.api.nvim_buf_is_valid(M.buffer_id) then
+        -- For terminal buffers, give a moment for processes to clean up
+        local bufname = vim.api.nvim_buf_get_name(M.buffer_id)
+        if bufname:match "^term://" then
+            local buffer_to_delete = M.buffer_id -- Capture buffer ID before defer_fn
+            vim.defer_fn(function()
+                if buffer_to_delete and vim.api.nvim_buf_is_valid(buffer_to_delete) then
+                    local success, err = pcall(vim.api.nvim_buf_delete, buffer_to_delete, { force = true })
+                    if not success then
+                        -- If force delete still fails, hide the buffer
+                        pcall(function()
+                            vim.bo[buffer_to_delete].buflisted = false
+                            vim.bo[buffer_to_delete].bufhidden = "wipe"
+                        end)
+                    end
+                end
+            end, 100) -- 100ms delay
+        else
+            local success, err = pcall(vim.api.nvim_buf_delete, M.buffer_id, { force = true })
+            if not success then
+                -- If force delete fails, try to hide it instead
+                pcall(function()
+                    vim.bo[M.buffer_id].buflisted = false
+                    vim.bo[M.buffer_id].bufhidden = "wipe"
+                end)
+            end
+        end
+    end
+
+    -- Reset all state
+    M.reset_state()
+end
+
+-- Get current buffer info
+function M.get_buffer_info()
+    return {
+        buffer_id = M.buffer_id,
+        window_id = M.window_id,
+        type = M.buffer_type,
+        job_id = M.current_job_id,
+    }
+end
+
+-- Set current job ID (for tracking by logcat/gradle modules)
+function M.set_current_job(job_id)
+    M.current_job_id = job_id
+end
+
+-- Check if buffer and window are valid
+function M.is_valid()
+    return M.buffer_id
+        and vim.api.nvim_buf_is_valid(M.buffer_id)
+        and M.window_id
+        and vim.api.nvim_win_is_valid(M.window_id)
+end
+
+-- Focus the buffer window
+function M.focus()
+    if M.window_id and vim.api.nvim_win_is_valid(M.window_id) then
+        vim.api.nvim_set_current_win(M.window_id)
+        return true
+    end
+    return false
+end
+
+-- Scroll to bottom of buffer
+function M.scroll_to_bottom()
+    if M.is_valid() then
+        vim.api.nvim_win_call(M.window_id, function()
+            vim.cmd "normal! G"
+        end)
+    end
+end
+
+return M

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -22,6 +22,8 @@ local defaults = {
         emulator_path = nil,
         qt_qpa_platform = nil,
         device_wait_timeout_ms = 120000,
+        boot_complete_timeout_ms = 120000,
+        boot_check_interval_ms = 3000,
         logcat_startup_delay_ms = 2000,
     },
 }
@@ -75,6 +77,8 @@ local function migrate_legacy_config(opts)
         "emulator_path",
         "qt_qpa_platform",
         "device_wait_timeout_ms",
+        "boot_complete_timeout_ms",
+        "boot_check_interval_ms",
         "logcat_startup_delay_ms",
     }
 

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -1,75 +1,108 @@
 local M = {}
 
-M.defaults = {
+-- Default configuration
+local defaults = {
     logcat = {
-        window_type = "horizontal", -- "horizontal" | "vertical" | "float"
-        height = 12,
+        mode = "horizontal", -- "horizontal" | "vertical" | "float"
+        height = 15,
         width = 80,
+        float_width = 120,
+        float_height = 30,
         filters = {
-            package = "mine", -- "mine" (auto-detect project package), specific package, or "none"
-            log_level = "v", -- v, d, i, w, e, f (lowercase)
-            tag = nil, -- specific tag to filter, or nil for no tag filtering
-            grep_pattern = nil, -- regex pattern for content filtering, or nil
+            package = "mine", -- "mine" (auto-detect), specific package, or "none"
+            log_level = "v", -- v, d, i, w, e, f
+            tag = nil,
+            grep_pattern = nil,
         },
     },
     android = {
-        auto_select_single_target = true, -- Auto-select if only one device/emulator
-        auto_launch_app = true, -- Auto-launch app after successful installation
-        adb_path = nil, -- Custom ADB path override
-        emulator_path = nil, -- Custom emulator path override
-        qt_qpa_platform = nil, -- Qt platform for emulator (e.g., "xcb" for Linux)
-        device_wait_timeout_ms = 30000, -- Timeout for waiting for device (ms)
-        logcat_startup_delay_ms = 2000, -- Delay after app launch before starting logcat (ms)
+        auto_select_single_target = true,
+        auto_launch_app = true,
+        adb_path = nil,
+        emulator_path = nil,
+        qt_qpa_platform = nil,
+        device_wait_timeout_ms = 120000,
+        logcat_startup_delay_ms = 2000,
     },
 }
 
-M.config = vim.deepcopy(M.defaults)
+M.config = vim.deepcopy(defaults)
+
+-- Validate configuration values
+local function validate_config(config)
+    local valid_modes = { horizontal = true, vertical = true, float = true }
+    if config.logcat and config.logcat.mode and not valid_modes[config.logcat.mode] then
+        vim.notify("Invalid logcat mode. Using 'horizontal'", vim.log.levels.WARN)
+        config.logcat.mode = "horizontal"
+    end
+
+    if config.logcat then
+        if config.logcat.height and (type(config.logcat.height) ~= "number" or config.logcat.height <= 0) then
+            config.logcat.height = 15
+        end
+        if config.logcat.width and (type(config.logcat.width) ~= "number" or config.logcat.width <= 0) then
+            config.logcat.width = 80
+        end
+    end
+end
+
+-- Handle legacy flat configuration format
+local function migrate_legacy_config(opts)
+    local migrated = {}
+
+    -- Migrate logcat options
+    if opts.logcat_mode or opts.logcat_height or opts.logcat_width or opts.logcat_filters then
+        migrated.logcat = {
+            mode = opts.logcat_mode,
+            height = opts.logcat_height,
+            width = opts.logcat_width,
+            filters = {},
+        }
+
+        if opts.logcat_filters then
+            migrated.logcat.filters.tag = opts.logcat_filters.tag
+            if opts.logcat_filters.priority then
+                migrated.logcat.filters.log_level = string.lower(opts.logcat_filters.priority)
+            end
+        end
+    end
+
+    -- Migrate android options
+    local android_keys = {
+        "auto_select_single_target",
+        "auto_launch_app",
+        "adb_path",
+        "emulator_path",
+        "qt_qpa_platform",
+        "device_wait_timeout_ms",
+        "logcat_startup_delay_ms",
+    }
+
+    local has_android_config = false
+    for _, key in ipairs(android_keys) do
+        if opts[key] ~= nil then
+            has_android_config = true
+            break
+        end
+    end
+
+    if has_android_config then
+        migrated.android = {}
+        for _, key in ipairs(android_keys) do
+            migrated.android[key] = opts[key]
+        end
+    end
+
+    return migrated
+end
 
 function M.setup(opts)
     opts = opts or {}
 
-    -- Handle legacy flat config for backward compatibility
-    local config_to_merge = {}
-    if opts.logcat_mode or opts.logcat_height or opts.logcat_width or opts.logcat_filters then
-        -- Handle legacy logcat_filters migration
-        local filters = {}
-        if opts.logcat_filters then
-            if opts.logcat_filters.tag then
-                filters.tag = opts.logcat_filters.tag
-            end
-            if opts.logcat_filters.priority then
-                filters.log_level = string.lower(opts.logcat_filters.priority)
-            end
-        end
+    -- Start with legacy migration
+    local config_to_merge = migrate_legacy_config(opts)
 
-        config_to_merge.logcat = {
-            window_type = opts.logcat_mode,
-            height = opts.logcat_height,
-            width = opts.logcat_width,
-            filters = filters,
-        }
-    end
-    if
-        opts.auto_select_single_target
-        or opts.auto_launch_app
-        or opts.adb_path
-        or opts.emulator_path
-        or opts.qt_qpa_platform
-        or opts.device_wait_timeout_ms
-        or opts.logcat_startup_delay_ms
-    then
-        config_to_merge.android = {
-            auto_select_single_target = opts.auto_select_single_target,
-            auto_launch_app = opts.auto_launch_app,
-            adb_path = opts.adb_path,
-            emulator_path = opts.emulator_path,
-            qt_qpa_platform = opts.qt_qpa_platform,
-            device_wait_timeout_ms = opts.device_wait_timeout_ms,
-            logcat_startup_delay_ms = opts.logcat_startup_delay_ms,
-        }
-    end
-
-    -- Merge nested config
+    -- Merge modern nested config
     if opts.logcat then
         config_to_merge.logcat = vim.tbl_extend("force", config_to_merge.logcat or {}, opts.logcat)
     end
@@ -77,64 +110,13 @@ function M.setup(opts)
         config_to_merge.android = vim.tbl_extend("force", config_to_merge.android or {}, opts.android)
     end
 
-    -- Validate logcat window_type
-    local valid_modes = { horizontal = true, vertical = true, float = true }
-    if
-        config_to_merge.logcat
-        and config_to_merge.logcat.window_type
-        and not valid_modes[config_to_merge.logcat.window_type]
-    then
-        vim.notify(
-            "Invalid logcat window_type: " .. config_to_merge.logcat.window_type .. ". Using default: horizontal",
-            vim.log.levels.WARN
-        )
-        config_to_merge.logcat.window_type = "horizontal"
-    end
-
-    -- Validate dimensions
-    if config_to_merge.logcat then
-        if
-            config_to_merge.logcat.height
-            and (type(config_to_merge.logcat.height) ~= "number" or config_to_merge.logcat.height <= 0)
-        then
-            vim.notify("Invalid logcat height. Using default: 12", vim.log.levels.WARN)
-            config_to_merge.logcat.height = 12
-        end
-        if
-            config_to_merge.logcat.width
-            and (type(config_to_merge.logcat.width) ~= "number" or config_to_merge.logcat.width <= 0)
-        then
-            vim.notify("Invalid logcat width. Using default: 80", vim.log.levels.WARN)
-            config_to_merge.logcat.width = 80
-        end
-    end
-
+    -- Validate and merge final config
+    validate_config(config_to_merge)
     M.config = vim.tbl_deep_extend("force", M.config, config_to_merge)
 end
 
 function M.get()
-    -- Return config with backward compatibility flat structure
-    local flat_config = vim.tbl_deep_extend("force", {}, M.config)
-
-    -- Add flat aliases for backward compatibility
-    if M.config.logcat then
-        flat_config.logcat_mode = M.config.logcat.window_type
-        flat_config.logcat_height = M.config.logcat.height
-        flat_config.logcat_width = M.config.logcat.width
-        flat_config.logcat_filters = M.config.logcat.filters
-    end
-
-    if M.config.android then
-        flat_config.auto_select_single_target = M.config.android.auto_select_single_target
-        flat_config.auto_launch_app = M.config.android.auto_launch_app
-        flat_config.adb_path = M.config.android.adb_path
-        flat_config.emulator_path = M.config.android.emulator_path
-        flat_config.qt_qpa_platform = M.config.android.qt_qpa_platform
-        flat_config.device_wait_timeout_ms = M.config.android.device_wait_timeout_ms
-        flat_config.logcat_startup_delay_ms = M.config.android.logcat_startup_delay_ms
-    end
-
-    return flat_config
+    return M.config
 end
 
 return M

--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -1,11 +1,8 @@
 local config = require "droid.config"
 local progress = require "droid.progress"
+local buffer = require "droid.buffer"
 
 local M = {}
-
-M.job_id = nil
-M.term_buf = nil
-M.term_win = nil
 
 local function find_gradlew()
     local gradlew = vim.fs.find("gradlew", { upward = true })[1]
@@ -39,38 +36,42 @@ local function run_gradle_task(cwd, gradlew, task, args, callback)
     local cmd_args = vim.iter({ task, args or {} }):flatten():totable()
     local cmd = gradlew .. " " .. table.concat(cmd_args, " ")
 
-    -- Create or reuse terminal buffer (clear and mark unmodified for reuse)
-    if M.term_buf and vim.api.nvim_buf_is_valid(M.term_buf) then
-        -- Make buffer modifiable, clear content, and mark as unmodified
-        vim.bo[M.term_buf].modifiable = true
-        vim.api.nvim_buf_set_lines(M.term_buf, 0, -1, false, {})
-        vim.bo[M.term_buf].modified = false
-    else
-        -- Create new terminal buffer
-        M.term_buf = vim.api.nvim_create_buf(false, true)
+    -- Get or create centralized buffer for gradle output with ownership
+    local buf, win = buffer.get_or_create("gradle", "horizontal", "gradle")
 
-        -- Handle buffer deletion
-        vim.api.nvim_create_autocmd("BufDelete", {
-            buffer = M.term_buf,
-            once = true,
-            callback = function()
-                M.term_buf = nil
-                M.term_win = nil
-            end,
-        })
+    if not buf then
+        -- Buffer is busy, callback with error
+        if callback then
+            vim.schedule(function()
+                callback(false, -1)
+            end)
+        end
+        return
     end
 
-    -- Set the terminal job to run in the buffer (in background)
-    vim.api.nvim_buf_call(M.term_buf, function()
-        M.job_id = vim.fn.jobstart(cmd, {
+    -- Set the terminal job to run in the buffer
+    vim.api.nvim_buf_call(buf, function()
+        local job_id = vim.fn.jobstart(cmd, {
             term = true,
             cwd = cwd,
             on_exit = function(_, exit_code)
-                M.job_id = nil
+                buffer.set_current_job_with_owner(nil, "gradle")
 
-                -- Show terminal window only on completion
+                -- Show terminal window on completion, auto-focus on failure
                 vim.schedule(function()
-                    M.open_gradle_window()
+                    -- Ensure window is visible
+                    if not buffer.is_valid() then
+                        buffer.get_or_create("gradle", "horizontal", "gradle")
+                    end
+
+                    -- Focus window on failure for easier debugging
+                    if exit_code ~= 0 then
+                        buffer.focus()
+                        buffer.scroll_to_bottom()
+                    end
+
+                    -- Release buffer lock after job completion
+                    buffer.release_lock "gradle"
 
                     -- Run callback
                     if callback then
@@ -79,37 +80,33 @@ local function run_gradle_task(cwd, gradlew, task, args, callback)
                 end)
             end,
         })
+        buffer.set_current_job_with_owner(job_id, "gradle")
     end)
 end
 
 function M.open_gradle_window()
-    if not M.term_buf or not vim.api.nvim_buf_is_valid(M.term_buf) then
+    local buf_info = buffer.get_buffer_info()
+    if not buf_info.buffer_id or buf_info.type ~= "gradle" then
         return false
     end
 
-    if M.term_win and vim.api.nvim_win_is_valid(M.term_win) then
+    if buffer.is_valid() then
         -- Focus existing window
-        vim.api.nvim_set_current_win(M.term_win)
+        buffer.focus()
     else
         -- Create new window
-        vim.cmd "botright split | resize 15"
-        M.term_win = vim.api.nvim_get_current_win()
-        vim.api.nvim_win_set_buf(M.term_win, M.term_buf)
-
-        -- Configure window appearance
-        vim.wo[M.term_win].number = false
-        vim.wo[M.term_win].relativenumber = false
-        vim.wo[M.term_win].signcolumn = "no"
+        buffer.get_or_create("gradle", "horizontal")
     end
 
     -- Scroll to bottom
-    vim.cmd "normal! G"
+    buffer.scroll_to_bottom()
     vim.cmd "stopinsert"
     return true
 end
 
 function M.is_gradle_window_visible()
-    return M.term_win and vim.api.nvim_win_is_valid(M.term_win)
+    local buf_info = buffer.get_buffer_info()
+    return buf_info.type == "gradle" and buffer.is_valid()
 end
 
 function M.show_log()
@@ -121,10 +118,14 @@ function M.show_log()
 end
 
 function M.hide_gradle_window()
-    if M.term_win and vim.api.nvim_win_is_valid(M.term_win) then
-        vim.api.nvim_win_close(M.term_win, false)
-        M.term_win = nil
-        return true
+    local buf_info = buffer.get_buffer_info()
+    if buf_info.type == "gradle" and buffer.is_valid() then
+        -- Close window but keep buffer for later reuse
+        local win_id = buf_info.window_id
+        if win_id and vim.api.nvim_win_is_valid(win_id) then
+            vim.api.nvim_win_close(win_id, true)
+            return true
+        end
     end
     return false
 end
@@ -260,29 +261,141 @@ end
 function M.install_debug(callback)
     local g = find_gradlew()
     if not g then
+        if callback then
+            vim.schedule(function()
+                callback(false, -1, "gradlew not found")
+            end)
+        end
         return
     end
 
     progress.start_spinner "Installing debug APK"
 
-    -- Use silent terminal for install (no window, just job control)
-    M.job_id = vim.fn.jobstart({ g.gradlew, "installDebug" }, {
+    -- Try to get buffer for background operation (no window display)
+    local buf, win = buffer.get_or_create("gradle", nil, "gradle")
+
+    if not buf then
+        -- Buffer is busy, show message and queue operation
+        progress.stop_spinner()
+        vim.notify("Buffer is busy, install operation queued", vim.log.levels.WARN)
+        if callback then
+            vim.schedule(function()
+                callback(false, -1, "Buffer busy")
+            end)
+        end
+        return
+    end
+
+    -- Use centralized job management
+    local job_id = vim.fn.jobstart({ g.gradlew, "installDebug" }, {
         cwd = g.cwd,
         on_exit = function(_, code)
-            M.job_id = nil
+            buffer.set_current_job_with_owner(nil, "gradle")
             progress.stop_spinner()
 
-            if code == 0 then
-                vim.notify("Debug APK installed successfully", vim.log.levels.INFO)
+            local success = code == 0
+            local message
+
+            if success then
+                message = "Debug APK installed successfully"
+                vim.notify(message, vim.log.levels.INFO)
             else
-                vim.notify("Debug APK installation failed (exit code: " .. code .. ")", vim.log.levels.ERROR)
+                message = "Debug APK installation failed (exit code: " .. code .. ")"
+                vim.notify(message, vim.log.levels.ERROR)
             end
 
+            -- Release buffer lock
+            buffer.release_lock "gradle"
+
             if callback then
-                vim.schedule(callback)
+                vim.schedule(function()
+                    callback(success, code, message)
+                end)
             end
         end,
     })
+
+    buffer.set_current_job_with_owner(job_id, "gradle")
+end
+
+-- Sequential build and install function for enhanced DroidRun workflow
+-- Args: callback(success, exit_code, message, step) - step indicates which phase failed
+function M.build_and_install_debug(callback)
+    local g = find_gradlew()
+    if not g then
+        if callback then
+            vim.schedule(function()
+                callback(false, -1, "gradlew not found", "build")
+            end)
+        end
+        return
+    end
+
+    progress.start_spinner "Building debug APK"
+
+    -- First: Build debug APK using centralized buffer
+    run_gradle_task(g.cwd, g.gradlew, "assembleDebug", nil, function(build_success, build_code)
+        if not build_success then
+            progress.stop_spinner()
+            local message = "Build failed (exit code: " .. build_code .. ")"
+            vim.notify(message, vim.log.levels.ERROR)
+
+            if callback then
+                vim.schedule(function()
+                    callback(false, build_code, message, "build")
+                end)
+            end
+            return
+        end
+
+        -- Build succeeded, now install
+        progress.update_spinner_message "Installing debug APK"
+
+        -- Get buffer for install operation (reuse if gradle buffer is available)
+        local buf, win = buffer.get_or_create("gradle", nil, "gradle")
+
+        if not buf then
+            progress.stop_spinner()
+            local message = "Buffer busy, install cancelled"
+            vim.notify(message, vim.log.levels.ERROR)
+            if callback then
+                vim.schedule(function()
+                    callback(false, -1, message, "install")
+                end)
+            end
+            return
+        end
+
+        local job_id = vim.fn.jobstart({ g.gradlew, "installDebug" }, {
+            cwd = g.cwd,
+            on_exit = function(_, install_code)
+                buffer.set_current_job_with_owner(nil, "gradle")
+                progress.stop_spinner()
+
+                local install_success = install_code == 0
+                local message
+
+                if install_success then
+                    message = "Build and install completed successfully"
+                    vim.notify(message, vim.log.levels.INFO)
+                else
+                    message = "Install failed (exit code: " .. install_code .. ")"
+                    vim.notify(message, vim.log.levels.ERROR)
+                end
+
+                -- Release buffer lock
+                buffer.release_lock "gradle"
+
+                if callback then
+                    vim.schedule(function()
+                        callback(install_success, install_code, message, "install")
+                    end)
+                end
+            end,
+        })
+
+        buffer.set_current_job_with_owner(job_id, "gradle")
+    end)
 end
 
 -- Composite function: install + launch (moved to keep compatibility)
@@ -290,7 +403,15 @@ function M.install_debug_and_launch(adb, device_id, callback)
     local config = require "droid.config"
     local cfg = config.get()
 
-    M.install_debug(function()
+    M.install_debug(function(success, exit_code, message)
+        if not success then
+            -- Install failed, don't launch
+            if callback then
+                vim.schedule(callback)
+            end
+            return
+        end
+
         -- Launch app if auto_launch_app is enabled
         if cfg.auto_launch_app then
             local android = require "droid.android"
@@ -304,21 +425,24 @@ function M.install_debug_and_launch(adb, device_id, callback)
 end
 
 function M.stop()
-    if M.job_id then
-        vim.fn.jobstop(M.job_id)
-        M.job_id = nil
+    local buf_info = buffer.get_buffer_info()
+    if buf_info.job_id and (buf_info.job_owner == "gradle" or buf_info.type == "gradle") then
+        buffer.stop_current_job_with_owner "gradle"
+        buffer.release_lock "gradle"
         vim.notify("Gradle task stopped", vim.log.levels.INFO)
     else
         vim.notify("No active Gradle task", vim.log.levels.WARN)
     end
 end
 
--- Clean up on Vim exit
+-- Clean up on Vim exit - now handled by centralized buffer management
 vim.api.nvim_create_autocmd("VimLeave", {
     callback = function()
-        if M.job_id then
-            vim.fn.jobstop(M.job_id)
-            M.job_id = nil
+        -- Force stop any gradle jobs and release ownership
+        local buf_info = buffer.get_buffer_info()
+        if buf_info.job_owner == "gradle" then
+            buffer.stop_current_job_with_owner "gradle"
+            buffer.release_lock "gradle"
         end
     end,
 })

--- a/lua/droid/logcat.lua
+++ b/lua/droid/logcat.lua
@@ -1,66 +1,13 @@
 local config = require "droid.config"
 local android = require "droid.android"
+local buffer = require "droid.buffer"
 
 local M = {}
 
-M.job_id = nil
-M.buf = nil
-M.win = nil
 M.auto_scroll = true
 M.current_filters = nil
 M.current_device_id = nil
 M.current_adb = nil
-
-local function create_logcat_buffer()
-    if M.buf and vim.api.nvim_buf_is_valid(M.buf) then
-        vim.api.nvim_buf_delete(M.buf, { force = true })
-    end
-    M.buf = vim.api.nvim_create_buf(false, true)
-    vim.bo[M.buf].filetype = "logcat"
-    return M.buf
-end
-
-local function attach_cleanup()
-    vim.api.nvim_create_autocmd("BufWipeout", {
-        buffer = M.buf,
-        callback = function()
-            if M.job_id then
-                vim.fn.jobstop(M.job_id)
-                M.job_id = nil
-                vim.notify("Logcat stopped (buffer closed)", vim.log.levels.INFO)
-            end
-        end,
-    })
-end
-
-local function open_window(mode)
-    local cfg = config.get()
-    mode = mode or cfg.logcat_mode
-
-    -- Open window according to mode
-    if mode == "horizontal" then
-        vim.cmd("botright split | resize " .. cfg.logcat_height)
-        M.win = vim.api.nvim_get_current_win()
-        vim.api.nvim_win_set_buf(M.win, M.buf)
-    elseif mode == "vertical" then
-        vim.cmd("vsplit | vertical resize " .. cfg.logcat_width)
-        M.win = vim.api.nvim_get_current_win()
-        vim.api.nvim_win_set_buf(M.win, M.buf)
-    elseif mode == "float" then
-        local opts = {
-            relative = "editor",
-            width = cfg.logcat_width,
-            height = cfg.logcat_height,
-            col = math.floor((vim.o.columns - cfg.logcat_width) / 2),
-            row = math.floor((vim.o.lines - cfg.logcat_height) / 2),
-            style = "minimal",
-            border = "rounded",
-            title = "Logcat",
-            title_pos = "center",
-        }
-        M.win = vim.api.nvim_open_win(M.buf, true, opts)
-    end
-end
 
 local function build_logcat_command(adb, device_id, filters, callback)
     local cmd = { adb, "-s", device_id, "logcat" }
@@ -195,6 +142,11 @@ function M.apply_filters(user_filters, adb, device_id)
         -- Check if filters would actually change the logcat command
         if filters_equivalent(M.current_filters, new_filters) then
             vim.notify("Filters unchanged, logcat continues running", vim.log.levels.INFO)
+            -- Ensure window is visible with ownership
+            local buf_info = buffer.get_buffer_info()
+            if buf_info.buffer_id and not buffer.is_valid() then
+                buffer.get_or_create("logcat", nil, "logcat")
+            end
             return
         end
 
@@ -267,17 +219,23 @@ function M.start(adb, device_id, mode, override_filters)
         end
     end
 
-    -- Smart reuse logic: check if we can reuse existing logcat session
-    if M.job_id and M.current_adb == adb and M.current_device_id == device_id then
+    -- Enhanced reuse logic with ownership checking
+    local buf_info = buffer.get_buffer_info()
+    if
+        buf_info.job_id
+        and M.current_adb == adb
+        and M.current_device_id == device_id
+        and (buf_info.job_owner == "logcat" or buf_info.type == "logcat")
+    then
         -- Same device and logcat is running
 
         if not override_filters or (type(override_filters) == "table" and next(override_filters) == nil) then
             -- No filter override or empty table (DroidRun, DroidLogcat case) - always reuse
             vim.notify("Reusing existing logcat session", vim.log.levels.INFO)
 
-            -- Reopen window if it was closed
-            if not M.win or not vim.api.nvim_win_is_valid(M.win) then
-                open_window(mode)
+            -- Ensure window is visible with ownership
+            if not buffer.is_valid() then
+                buffer.get_or_create("logcat", mode, "logcat")
             end
             return
         else
@@ -285,9 +243,9 @@ function M.start(adb, device_id, mode, override_filters)
             if filters_equivalent(M.current_filters, active_filters) then
                 vim.notify("Logcat filters unchanged, reusing session", vim.log.levels.INFO)
 
-                -- Reopen window if it was closed
-                if not M.win or not vim.api.nvim_win_is_valid(M.win) then
-                    open_window(mode)
+                -- Ensure window is visible with ownership
+                if not buffer.is_valid() then
+                    buffer.get_or_create("logcat", mode, "logcat")
                 end
                 return
             else
@@ -300,24 +258,19 @@ function M.start(adb, device_id, mode, override_filters)
     M.current_device_id = device_id
     M.current_adb = adb
 
-    -- Handle existing logcat session
-    if M.job_id then
-        vim.fn.jobstop(M.job_id)
-        M.job_id = nil
-
-        -- If we're restarting with existing buffer, clear it but don't recreate
-        if M.buf and vim.api.nvim_buf_is_valid(M.buf) then
-            vim.api.nvim_buf_set_lines(M.buf, 0, -1, false, {})
-            vim.notify("Applying filters...", vim.log.levels.INFO)
-        end
+    -- Handle existing logcat session with ownership validation
+    if buf_info.job_id then
+        buffer.stop_current_job_with_owner "logcat"
+        vim.notify("Applying filters...", vim.log.levels.INFO)
     end
 
-    -- Create buffer and window only if they don't exist
-    if not M.buf or not vim.api.nvim_buf_is_valid(M.buf) then
-        create_logcat_buffer()
-    end
-    if not M.win or not vim.api.nvim_win_is_valid(M.win) then
-        open_window(mode)
+    -- Get or create centralized buffer with logcat ownership
+    local buf, win = buffer.get_or_create("logcat", mode, "logcat")
+
+    if not buf then
+        -- Buffer is busy with another operation
+        vim.notify("Buffer is busy. Logcat request queued.", vim.log.levels.WARN)
+        return
     end
 
     build_logcat_command(adb, device_id, active_filters, function(cmd)
@@ -338,24 +291,36 @@ function M.start(adb, device_id, mode, override_filters)
                     end
 
                     if #filtered_data > 0 then
-                        vim.api.nvim_buf_set_lines(M.buf, -1, -1, false, filtered_data)
-                        if M.auto_scroll and M.win and vim.api.nvim_win_is_valid(M.win) then
-                            local line_count = vim.api.nvim_buf_line_count(M.buf)
-                            vim.api.nvim_win_set_cursor(M.win, { line_count, 0 })
+                        local buf_info = buffer.get_buffer_info()
+                        if buf_info.buffer_id and vim.api.nvim_buf_is_valid(buf_info.buffer_id) then
+                            -- Temporarily make buffer modifiable for writing
+                            local was_modifiable = vim.bo[buf_info.buffer_id].modifiable
+                            vim.bo[buf_info.buffer_id].modifiable = true
+
+                            vim.api.nvim_buf_set_lines(buf_info.buffer_id, -1, -1, false, filtered_data)
+
+                            -- Restore original modifiable state
+                            vim.bo[buf_info.buffer_id].modifiable = was_modifiable
+
+                            if M.auto_scroll and buffer.is_valid() then
+                                buffer.scroll_to_bottom()
+                            end
                         end
                     end
                 end
             end,
             on_exit = function(_, _, _)
-                M.job_id = nil
+                buffer.set_current_job_with_owner(nil, "logcat")
                 M.current_device_id = nil
                 M.current_adb = nil
+                -- Release buffer lock when logcat exits
+                buffer.release_lock "logcat"
                 vim.notify("Logcat process exited", vim.log.levels.INFO)
             end,
         }
 
-        M.job_id = vim.fn.jobstart(cmd, job_opts)
-        attach_cleanup()
+        local job_id = vim.fn.jobstart(cmd, job_opts)
+        buffer.set_current_job_with_owner(job_id, "logcat")
     end)
 end
 
@@ -365,9 +330,10 @@ function M.open(adb, device_id, mode)
 end
 
 function M.stop()
-    if M.job_id then
-        vim.fn.jobstop(M.job_id)
-        M.job_id = nil
+    local buf_info = buffer.get_buffer_info()
+    if buf_info.job_id and (buf_info.job_owner == "logcat" or buf_info.type == "logcat") then
+        buffer.stop_current_job_with_owner "logcat"
+        buffer.release_lock "logcat"
         M.current_device_id = nil
         M.current_adb = nil
         vim.notify("Logcat stopped", vim.log.levels.INFO)
@@ -390,7 +356,8 @@ function M.refresh_logcat(adb, device_id, mode, filters)
 end
 
 function M.is_running()
-    return M.job_id ~= nil
+    local buf_info = buffer.get_buffer_info()
+    return buf_info.job_id ~= nil and (buf_info.job_owner == "logcat" or buf_info.type == "logcat")
 end
 
 function M.toggle_auto_scroll()
@@ -451,10 +418,7 @@ end
 -- Clean up on Vim exit
 vim.api.nvim_create_autocmd("VimLeave", {
     callback = function()
-        if M.job_id then
-            vim.fn.jobstop(M.job_id)
-            M.job_id = nil
-        end
+        buffer.close()
     end,
 })
 


### PR DESCRIPTION
## This pull request include several major changes:

1.  centralize buffer manager in one file and refactor any function that use buffer
2. Fixed Config Access (logcat.lua):
    -- Before: cfg.logcat_filters (incorrect)
    -- After:  cfg.logcat.filters (correct)
   local base_filters = cfg.logcat.filters or {}
4. Fixed Filter Override (actions.lua):
    -- Before: logcat.refresh_logcat(tools.adb, device_id, nil, {})
    -- After:  logcat.refresh_logcat(tools.adb, device_id, nil, nil)