### PR TITLE
feat: optional android-cli backend for emulator, deploy, screenshots, and docs

### DIFF
--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -148,7 +148,12 @@ function M.build_and_run(on_complete)
             execute_build_install(tools, target.id, true, on_complete)
         elseif target.type == "avd" then
             progress.start_spinner "Starting emulator"
-            android.start_emulator(tools.emulator, target.avd)
+            local cli = require("droid.backends.android_cli")
+            if cli.prefers("emulator") then
+                cli.start_emulator(target.avd)
+            else
+                android.start_emulator(tools.emulator, target.avd)
+            end
             android.wait_for_device_ready(tools.adb, function(device_id)
                 progress.stop_spinner()
                 if not device_id then
@@ -185,7 +190,12 @@ function M.install_only(on_complete)
             execute_build_install(tools, target.id, false, on_complete)
         elseif target.type == "avd" then
             progress.start_spinner "Starting emulator"
-            android.start_emulator(tools.emulator, target.avd)
+            local cli = require("droid.backends.android_cli")
+            if cli.prefers("emulator") then
+                cli.start_emulator(target.avd)
+            else
+                android.start_emulator(tools.emulator, target.avd)
+            end
             android.wait_for_device_ready(tools.adb, function(device_id)
                 progress.stop_spinner()
                 if not device_id then

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -25,7 +25,73 @@ local function handle_post_install(tools, device_id, launch_app)
     end
 end
 
+-- :DroidRun fast path: gradle assemble<Variant> + `android run --apks=…`.
+-- `android run` installs and launches in one call, so we skip the
+-- gradle install task and the am-start step. Only used when the caller
+-- wants to launch (:DroidRun, not :DroidInstall) and the CLI backend is
+-- preferred for deploy and actually available.
+local function execute_build_run_via_cli(tools, device_id, on_complete)
+    local cli = require("droid.backends.android_cli")
+    local g = gradle.find_gradlew()
+    if not g then
+        if on_complete then
+            on_complete()
+        end
+        return
+    end
+
+    gradle.build(function(build_ok)
+        if not build_ok then
+            if on_complete then
+                on_complete()
+            end
+            return
+        end
+
+        local apks = gradle.find_apks_for_variant(g.cwd, gradle.selected_variant)
+        if #apks == 0 then
+            vim.notify(
+                ("No APKs found for %s under */build/outputs/apk/%s/ -- falling back to gradle install"):format(
+                    gradle.selected_variant,
+                    gradle.selected_variant:lower()
+                ),
+                vim.log.levels.WARN
+            )
+            gradle.install(function()
+                if on_complete then
+                    on_complete()
+                end
+                handle_post_install(tools, device_id, true)
+            end)
+            return
+        end
+
+        cli.run_apks(apks, { device = device_id }, function(ok)
+            if on_complete then
+                on_complete()
+            end
+            if not ok then
+                return
+            end
+            vim.notify("android-cli run completed", vim.log.levels.INFO)
+            local cfg = config.get()
+            local delay_ms = cfg.android.logcat_startup_delay_ms or 2000
+            vim.defer_fn(function()
+                logcat.refresh_logcat(tools.adb, device_id, nil, nil)
+            end, delay_ms)
+        end)
+    end)
+end
+
 local function execute_build_install(tools, device_id, launch_app, on_complete)
+    if launch_app then
+        local cli = require("droid.backends.android_cli")
+        if cli.prefers("deploy") then
+            execute_build_run_via_cli(tools, device_id, on_complete)
+            return
+        end
+    end
+
     gradle.build_and_install(function(success, exit_code, message, step)
         if on_complete then
             on_complete()

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -51,9 +51,8 @@ local function execute_build_run_via_cli(tools, device_id, on_complete)
         local apks = gradle.find_apks_for_variant(g.cwd, gradle.selected_variant)
         if #apks == 0 then
             vim.notify(
-                ("No APKs found for %s under */build/outputs/apk/%s/ -- falling back to gradle install"):format(
-                    gradle.selected_variant,
-                    gradle.selected_variant:lower()
+                ("No APKs found for variant %s under */build/outputs/apk/ -- falling back to gradle install"):format(
+                    gradle.selected_variant
                 ),
                 vim.log.levels.WARN
             )

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -57,11 +57,13 @@ local function execute_build_run_via_cli(tools, device_id, on_complete)
                 ),
                 vim.log.levels.WARN
             )
-            gradle.install(function()
+            gradle.install(function(install_ok)
                 if on_complete then
                     on_complete()
                 end
-                handle_post_install(tools, device_id, true)
+                if install_ok then
+                    handle_post_install(tools, device_id, true)
+                end
             end)
             return
         end

--- a/lua/droid/actions.lua
+++ b/lua/droid/actions.lua
@@ -31,7 +31,7 @@ end
 -- wants to launch (:DroidRun, not :DroidInstall) and the CLI backend is
 -- preferred for deploy and actually available.
 local function execute_build_run_via_cli(tools, device_id, on_complete)
-    local cli = require("droid.backends.android_cli")
+    local cli = require "droid.backends.android_cli"
     local g = gradle.find_gradlew()
     if not g then
         if on_complete then
@@ -86,8 +86,8 @@ end
 
 local function execute_build_install(tools, device_id, launch_app, on_complete)
     if launch_app then
-        local cli = require("droid.backends.android_cli")
-        if cli.prefers("deploy") then
+        local cli = require "droid.backends.android_cli"
+        if cli.prefers "deploy" then
             execute_build_run_via_cli(tools, device_id, on_complete)
             return
         end
@@ -147,8 +147,8 @@ function M.build_and_run(on_complete)
             execute_build_install(tools, target.id, true, on_complete)
         elseif target.type == "avd" then
             progress.start_spinner "Starting emulator"
-            local cli = require("droid.backends.android_cli")
-            if cli.prefers("emulator") then
+            local cli = require "droid.backends.android_cli"
+            if cli.prefers "emulator" then
                 cli.start_emulator(target.avd)
             else
                 android.start_emulator(tools.emulator, target.avd)
@@ -189,8 +189,8 @@ function M.install_only(on_complete)
             execute_build_install(tools, target.id, false, on_complete)
         elseif target.type == "avd" then
             progress.start_spinner "Starting emulator"
-            local cli = require("droid.backends.android_cli")
-            if cli.prefers("emulator") then
+            local cli = require "droid.backends.android_cli"
+            if cli.prefers "emulator" then
                 cli.start_emulator(target.avd)
             else
                 android.start_emulator(tools.emulator, target.avd)

--- a/lua/droid/android.lua
+++ b/lua/droid/android.lua
@@ -659,10 +659,7 @@ local function create_emulator_via_cli(cli)
             cli.create_emulator(choice, function(ok, stdout)
                 if ok then
                     local detail = vim.trim(stdout)
-                    vim.notify(
-                        "Emulator created" .. (#detail > 0 and ("\n" .. detail) or ""),
-                        vim.log.levels.INFO
-                    )
+                    vim.notify("Emulator created" .. (#detail > 0 and ("\n" .. detail) or ""), vim.log.levels.INFO)
                 end
             end)
         end)
@@ -670,8 +667,8 @@ local function create_emulator_via_cli(cli)
 end
 
 function M.create_emulator()
-    local cli = require("droid.backends.android_cli")
-    if cli.prefers("emulator") then
+    local cli = require "droid.backends.android_cli"
+    if cli.prefers "emulator" then
         create_emulator_via_cli(cli)
         return
     end
@@ -713,8 +710,8 @@ local function prompt_and_launch(avds, launch_fn)
 end
 
 function M.launch_emulator()
-    local cli = require("droid.backends.android_cli")
-    if cli.prefers("emulator") then
+    local cli = require "droid.backends.android_cli"
+    if cli.prefers "emulator" then
         cli.list_avds(function(avds)
             prompt_and_launch(avds, function(choice)
                 cli.start_emulator(choice)
@@ -772,8 +769,8 @@ function M.stop_emulator()
             end
             vim.notify("Stopping emulator: " .. choice.id, vim.log.levels.INFO)
 
-            local cli = require("droid.backends.android_cli")
-            if cli.prefers("emulator") then
+            local cli = require "droid.backends.android_cli"
+            if cli.prefers "emulator" then
                 cli.stop_emulator(choice.id, function(ok)
                     if ok then
                         vim.notify("Emulator stopped successfully: " .. choice.id, vim.log.levels.INFO)

--- a/lua/droid/android.lua
+++ b/lua/droid/android.lua
@@ -657,15 +657,8 @@ end
 
 local CREATE_EMULATOR_SENTINEL = "+ Create New Emulator"
 
-function M.launch_emulator()
-    local emulator = M.get_emulator_path()
-    if not emulator then
-        return
-    end
-
-    local avds = M.get_available_avds(emulator)
+local function prompt_and_launch(avds, launch_fn)
     table.insert(avds, CREATE_EMULATOR_SENTINEL)
-
     vim.ui.select(avds, {
         prompt = "Select Emulator to launch:",
         format_item = function(avd)
@@ -675,16 +668,33 @@ function M.launch_emulator()
         if not choice then
             return
         end
-
         if choice == CREATE_EMULATOR_SENTINEL then
             M.create_emulator()
             return
         end
-
         vim.notify("Launching Emulator: " .. choice, vim.log.levels.INFO)
+        launch_fn(choice)
+    end)
+end
 
+function M.launch_emulator()
+    local cli = require("droid.backends.android_cli")
+    if cli.prefers("emulator") then
+        cli.list_avds(function(avds)
+            prompt_and_launch(avds, function(choice)
+                cli.start_emulator(choice)
+            end)
+        end)
+        return
+    end
+
+    local emulator = M.get_emulator_path()
+    if not emulator then
+        return
+    end
+
+    prompt_and_launch(M.get_available_avds(emulator), function(choice)
         local job_args = M.build_emulator_command(emulator, { "-avd", choice })
-
         vim.fn.jobstart(job_args, {
             on_exit = vim.schedule_wrap(function(_, exit_code)
                 if exit_code ~= 0 then
@@ -721,20 +731,31 @@ function M.stop_emulator()
                 return emu.id .. " (" .. emu.name .. ")"
             end,
         }, function(choice)
-            if choice then
-                vim.notify("Stopping emulator: " .. choice.id, vim.log.levels.INFO)
-                vim.fn.jobstart({ adb, "-s", choice.id, "emu", "kill" }, {
-                    on_exit = vim.schedule_wrap(function(_, exit_code)
-                        if exit_code == 0 then
-                            vim.notify("Emulator stopped successfully: " .. choice.id, vim.log.levels.INFO)
-                        else
-                            vim.notify("Failed to stop emulator: " .. choice.id, vim.log.levels.ERROR)
-                        end
-                    end),
-                })
-            else
+            if not choice then
                 vim.notify("Stop cancelled", vim.log.levels.INFO)
+                return
             end
+            vim.notify("Stopping emulator: " .. choice.id, vim.log.levels.INFO)
+
+            local cli = require("droid.backends.android_cli")
+            if cli.prefers("emulator") then
+                cli.stop_emulator(choice.id, function(ok)
+                    if ok then
+                        vim.notify("Emulator stopped successfully: " .. choice.id, vim.log.levels.INFO)
+                    end
+                end)
+                return
+            end
+
+            vim.fn.jobstart({ adb, "-s", choice.id, "emu", "kill" }, {
+                on_exit = vim.schedule_wrap(function(_, exit_code)
+                    if exit_code == 0 then
+                        vim.notify("Emulator stopped successfully: " .. choice.id, vim.log.levels.INFO)
+                    else
+                        vim.notify("Failed to stop emulator: " .. choice.id, vim.log.levels.ERROR)
+                    end
+                end),
+            })
         end)
     end)
 end

--- a/lua/droid/android.lua
+++ b/lua/droid/android.lua
@@ -640,7 +640,42 @@ local function run_avd_create(avdmanager, name, image_pkg, device_id)
     end
 end
 
+local function create_emulator_via_cli(cli)
+    cli.list_emulator_profiles(function(profiles)
+        if #profiles == 0 then
+            vim.notify("android-cli returned no emulator profiles", vim.log.levels.WARN)
+            return
+        end
+        vim.ui.select(profiles, {
+            prompt = "Select emulator profile:",
+            format_item = function(p)
+                return p
+            end,
+        }, function(choice)
+            if not choice then
+                return
+            end
+            vim.notify("Creating emulator from profile: " .. choice, vim.log.levels.INFO)
+            cli.create_emulator(choice, function(ok, stdout)
+                if ok then
+                    local detail = vim.trim(stdout)
+                    vim.notify(
+                        "Emulator created" .. (#detail > 0 and ("\n" .. detail) or ""),
+                        vim.log.levels.INFO
+                    )
+                end
+            end)
+        end)
+    end)
+end
+
 function M.create_emulator()
+    local cli = require("droid.backends.android_cli")
+    if cli.prefers("emulator") then
+        create_emulator_via_cli(cli)
+        return
+    end
+
     local avdmanager = validate_avdmanager()
     if not avdmanager then
         return

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -218,6 +218,50 @@ function M.stop_emulator(serial, callback)
     end)
 end
 
+--- Deploy one or more APKs via `android run --apks=…`.
+--- Replaces the `adb install` + `am start` sequence with a single CLI call
+--- that handles multi-APK splits and activity launch in one shot.
+---@param apks string[] absolute APK paths
+---@param opts { device?: string, activity?: string, debug?: boolean, type?: string }
+---@param callback fun(ok: boolean, message: string)
+function M.run_apks(apks, opts, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback(false, "android-cli not available")
+        return
+    end
+    if #apks == 0 then
+        callback(false, "no APKs supplied")
+        return
+    end
+    opts = opts or {}
+
+    local args = { exe, "run", "--apks=" .. table.concat(apks, ",") }
+    if opts.device then
+        table.insert(args, "--device=" .. opts.device)
+    end
+    if opts.activity then
+        table.insert(args, "--activity=" .. opts.activity)
+    end
+    if opts.debug then
+        table.insert(args, "--debug")
+    end
+    if opts.type then
+        table.insert(args, "--type=" .. opts.type)
+    end
+
+    vim.system(args, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("run", result)
+                callback(false, vim.trim(result.stderr or ""))
+                return
+            end
+            callback(true, vim.trim(result.stdout or ""))
+        end)
+    end)
+end
+
 --- Search the Android Knowledge Base via `android docs search "<query>"`.
 --- Output is assumed to be one `kb://` URL per non-empty line; lines that
 --- don't start with `kb://` are passed through verbatim so a richer

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -218,6 +218,58 @@ function M.stop_emulator(serial, callback)
     end)
 end
 
+--- Search the Android Knowledge Base via `android docs search "<query>"`.
+--- Output is assumed to be one `kb://` URL per non-empty line; lines that
+--- don't start with `kb://` are passed through verbatim so a richer
+--- "title\turl" format from future CLI versions still renders something.
+---@param query string
+---@param callback fun(results: string[])
+function M.docs_search(query, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback({})
+        return
+    end
+    vim.system({ exe, "docs", "search", query }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("docs search", result)
+                callback({})
+                return
+            end
+            local results = {}
+            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+                local trimmed = vim.trim(line)
+                if #trimmed > 0 then
+                    table.insert(results, trimmed)
+                end
+            end
+            callback(results)
+        end)
+    end)
+end
+
+--- Fetch a single KB document via `android docs fetch <kb-url>`.
+---@param url string e.g. "kb://android/topic/performance/overview"
+---@param callback fun(ok: boolean, body: string)
+function M.docs_fetch(url, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback(false, "")
+        return
+    end
+    vim.system({ exe, "docs", "fetch", url }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("docs fetch", result)
+                callback(false, result.stdout or "")
+                return
+            end
+            callback(true, result.stdout or "")
+        end)
+    end)
+end
+
 --- Capture a screenshot of the connected device via `android screen capture`.
 ---@param opts { output: string, annotate: boolean }
 ---@param callback fun(ok: boolean, output_path: string)

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -218,4 +218,29 @@ function M.stop_emulator(serial, callback)
     end)
 end
 
+--- Capture a screenshot of the connected device via `android screen capture`.
+---@param opts { output: string, annotate: boolean }
+---@param callback fun(ok: boolean, output_path: string)
+function M.screen_capture(opts, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback(false, opts.output)
+        return
+    end
+    local args = { exe, "screen", "capture", "--output=" .. opts.output }
+    if opts.annotate then
+        table.insert(args, "--annotate")
+    end
+    vim.system(args, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("screen capture", result)
+                callback(false, opts.output)
+                return
+            end
+            callback(true, opts.output)
+        end)
+    end)
+end
+
 return M

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -91,4 +91,82 @@ function M.prefers(capability)
     return prefer_for[capability] == true
 end
 
+local function notify_failure(action, result)
+    local stderr = vim.trim(result.stderr or "")
+    local msg = ("android-cli %s failed (exit %d)"):format(action, result.code or -1)
+    if #stderr > 0 then
+        msg = msg .. ": " .. stderr
+    end
+    vim.notify(msg, vim.log.levels.ERROR)
+end
+
+--- List available AVD names via `android emulator list`.
+--- Assumes one AVD name per output line; blank lines are ignored.
+---@param callback fun(avds: string[])
+function M.list_avds(callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback({})
+        return
+    end
+    vim.system({ exe, "emulator", "list" }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("emulator list", result)
+                callback({})
+                return
+            end
+            local avds = {}
+            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+                local trimmed = vim.trim(line)
+                if #trimmed > 0 then
+                    table.insert(avds, trimmed)
+                end
+            end
+            callback(avds)
+        end)
+    end)
+end
+
+--- Launch an emulator via `android emulator start <name>`.
+--- The command is fire-and-forget; android-cli detaches the emulator process.
+---@param name string AVD name
+function M.start_emulator(name)
+    local exe = resolve_binary()
+    if not exe then
+        return
+    end
+    vim.fn.jobstart({ exe, "emulator", "start", name }, {
+        on_exit = vim.schedule_wrap(function(_, exit_code)
+            if exit_code ~= 0 then
+                vim.notify(
+                    ("android-cli emulator start failed for %s (exit %d)"):format(name, exit_code),
+                    vim.log.levels.ERROR
+                )
+            end
+        end),
+    })
+end
+
+--- Stop a running emulator via `android emulator stop <serial>`.
+---@param serial string e.g. "emulator-5554"
+---@param callback fun(ok: boolean)
+function M.stop_emulator(serial, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback(false)
+        return
+    end
+    vim.system({ exe, "emulator", "stop", serial }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("emulator stop", result)
+                callback(false)
+                return
+            end
+            callback(true)
+        end)
+    end)
+end
+
 return M

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -7,7 +7,7 @@
 
 local M = {}
 
-local config = require("droid.config")
+local config = require "droid.config"
 
 ---@type boolean|nil
 local _cached_available = nil
@@ -15,7 +15,7 @@ local _cached_available = nil
 local _cached_version = nil
 
 local function is_windows()
-    return vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+    return vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1
 end
 
 --- Reset detection cache. Useful for tests and `:checkhealth` reruns.
@@ -32,7 +32,7 @@ local function resolve_binary()
         return nil
     end
 
-    local exe = vim.fn.exepath("android")
+    local exe = vim.fn.exepath "android"
     if exe == nil or exe == "" then
         return nil
     end
@@ -106,18 +106,18 @@ end
 function M.list_avds(callback)
     local exe = resolve_binary()
     if not exe then
-        callback({})
+        callback {}
         return
     end
     vim.system({ exe, "emulator", "list" }, { text = true }, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
                 notify_failure("emulator list", result)
-                callback({})
+                callback {}
                 return
             end
             local avds = {}
-            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+            for line in (result.stdout or ""):gmatch "[^\r\n]+" do
                 local trimmed = vim.trim(line)
                 if #trimmed > 0 then
                     table.insert(avds, trimmed)
@@ -153,18 +153,18 @@ end
 function M.list_emulator_profiles(callback)
     local exe = resolve_binary()
     if not exe then
-        callback({})
+        callback {}
         return
     end
     vim.system({ exe, "emulator", "create", "--list-profiles" }, { text = true }, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
                 notify_failure("emulator create --list-profiles", result)
-                callback({})
+                callback {}
                 return
             end
             local profiles = {}
-            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+            for line in (result.stdout or ""):gmatch "[^\r\n]+" do
                 local trimmed = vim.trim(line)
                 if #trimmed > 0 then
                     table.insert(profiles, trimmed)
@@ -271,18 +271,18 @@ end
 function M.docs_search(query, callback)
     local exe = resolve_binary()
     if not exe then
-        callback({})
+        callback {}
         return
     end
     vim.system({ exe, "docs", "search", query }, { text = true }, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
                 notify_failure("docs search", result)
-                callback({})
+                callback {}
                 return
             end
             local results = {}
-            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+            for line in (result.stdout or ""):gmatch "[^\r\n]+" do
                 local trimmed = vim.trim(line)
                 if #trimmed > 0 then
                     table.insert(results, trimmed)

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -129,23 +129,21 @@ function M.list_avds(callback)
 end
 
 --- Launch an emulator via `android emulator start <name>`.
---- The command is fire-and-forget; android-cli detaches the emulator process.
+--- Long-running: the callback only fires when the emulator process exits,
+--- which is typically when the user shuts it down.
 ---@param name string AVD name
 function M.start_emulator(name)
     local exe = resolve_binary()
     if not exe then
         return
     end
-    vim.fn.jobstart({ exe, "emulator", "start", name }, {
-        on_exit = vim.schedule_wrap(function(_, exit_code)
-            if exit_code ~= 0 then
-                vim.notify(
-                    ("android-cli emulator start failed for %s (exit %d)"):format(name, exit_code),
-                    vim.log.levels.ERROR
-                )
-            end
-        end),
-    })
+    vim.system({ exe, "emulator", "start", name }, { text = true }, function(result)
+        if result.code ~= 0 then
+            vim.schedule(function()
+                notify_failure(("emulator start %s"):format(name), result)
+            end)
+        end
+    end)
 end
 
 --- Stop a running emulator via `android emulator stop <serial>`.

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -1,0 +1,94 @@
+--- android-cli backend wrapper.
+--- Detects the `android` binary on PATH and exposes typed helpers for the
+--- subset of commands droid-nvim cares about. All callers must gate on
+--- `M.is_available()` and respect `config.android_cli.prefer_for.<capability>`
+--- before routing through here -- existing adb/avdmanager paths remain the
+--- fallback whenever this backend is disabled, unavailable, or not preferred.
+
+local M = {}
+
+local config = require("droid.config")
+
+---@type boolean|nil
+local _cached_available = nil
+---@type string|nil
+local _cached_version = nil
+
+local function is_windows()
+    return vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+end
+
+--- Reset detection cache. Useful for tests and `:checkhealth` reruns.
+function M.reset_cache()
+    _cached_available = nil
+    _cached_version = nil
+end
+
+--- Resolve the `android` executable path, honoring the user `enabled` setting.
+---@return string|nil path nil when disabled or not found
+local function resolve_binary()
+    local cfg = config.get().android_cli or {}
+    if cfg.enabled == false then
+        return nil
+    end
+
+    local exe = vim.fn.exepath("android")
+    if exe == nil or exe == "" then
+        return nil
+    end
+    return exe
+end
+
+--- Is the android-cli backend usable in this environment?
+--- Cached after the first call; use `reset_cache()` to re-probe.
+---@return boolean
+function M.is_available()
+    if _cached_available ~= nil then
+        return _cached_available
+    end
+
+    local exe = resolve_binary()
+    if not exe then
+        _cached_available = false
+        return false
+    end
+
+    local result = vim.system({ exe, "-V" }, { text = true }):wait()
+    if result.code ~= 0 then
+        _cached_available = false
+        return false
+    end
+
+    _cached_version = vim.trim(result.stdout or "")
+    _cached_available = true
+    return true
+end
+
+--- Detected version string (output of `android -V`), or nil if unavailable.
+---@return string|nil
+function M.version()
+    if _cached_available == nil then
+        M.is_available()
+    end
+    return _cached_version
+end
+
+--- Check whether a specific capability should be routed through android-cli.
+--- Returns false when the backend is unavailable, disabled, or the
+--- capability flag is off. Also auto-disables `emulator` on Windows where
+--- `android emulator` is not supported.
+---@param capability "emulator"|"deploy"|"screenshot"|"docs"
+---@return boolean
+function M.prefers(capability)
+    if not M.is_available() then
+        return false
+    end
+    if capability == "emulator" and is_windows() then
+        return false
+    end
+    local cfg = config.get().android_cli or {}
+    local prefer_for = cfg.prefer_for or {}
+    return prefer_for[capability] == true
+end
+
+return M

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -146,6 +146,57 @@ function M.start_emulator(name)
     end)
 end
 
+--- List emulator profiles via `android emulator create --list-profiles`.
+--- Each profile is a device template the CLI knows how to instantiate
+--- (e.g. "medium_phone", "small_phone", "pixel_tablet").
+---@param callback fun(profiles: string[])
+function M.list_emulator_profiles(callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback({})
+        return
+    end
+    vim.system({ exe, "emulator", "create", "--list-profiles" }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure("emulator create --list-profiles", result)
+                callback({})
+                return
+            end
+            local profiles = {}
+            for line in (result.stdout or ""):gmatch("[^\r\n]+") do
+                local trimmed = vim.trim(line)
+                if #trimmed > 0 then
+                    table.insert(profiles, trimmed)
+                end
+            end
+            callback(profiles)
+        end)
+    end)
+end
+
+--- Create an emulator from a profile via `android emulator create --profile=<p>`.
+--- The CLI picks the AVD name and SDK image; no extra prompting is required.
+---@param profile string profile name from `list_emulator_profiles`
+---@param callback fun(ok: boolean, stdout: string)
+function M.create_emulator(profile, callback)
+    local exe = resolve_binary()
+    if not exe then
+        callback(false, "")
+        return
+    end
+    vim.system({ exe, "emulator", "create", "--profile=" .. profile }, { text = true }, function(result)
+        vim.schedule(function()
+            if result.code ~= 0 then
+                notify_failure(("emulator create --profile=%s"):format(profile), result)
+                callback(false, result.stdout or "")
+                return
+            end
+            callback(true, result.stdout or "")
+        end)
+    end)
+end
+
 --- Stop a running emulator via `android emulator stop <serial>`.
 ---@param serial string e.g. "emulator-5554"
 ---@param callback fun(ok: boolean)

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -77,7 +77,7 @@ end
 --- Returns false when the backend is unavailable, disabled, or the
 --- capability flag is off. Also auto-disables `emulator` on Windows where
 --- `android emulator` is not supported.
----@param capability "emulator"|"deploy"|"screenshot"|"docs"
+---@param capability "emulator"|"deploy"
 ---@return boolean
 function M.prefers(capability)
     if not M.is_available() then
@@ -100,8 +100,30 @@ local function notify_failure(action, result)
     vim.notify(msg, vim.log.levels.ERROR)
 end
 
+--- Parse a list-style CLI output (one identifier per line, optional
+--- trailing metadata) into a clean array of identifiers. Tolerates:
+---   - blank lines and indented entries
+---   - trailing tabs / spaces / metadata ("name\tstatus", "name (path)")
+---   - header lines that don't start with an identifier character
+--- Returns only tokens whose first character is a letter, digit, or
+--- underscore -- AVD names and profile names match that shape; ANSI
+--- escapes, prompts, and decorative headers don't.
+---@param stdout string
+---@return string[]
+local function parse_id_list(stdout)
+    local out = {}
+    for line in (stdout or ""):gmatch "[^\r\n]+" do
+        local token = vim.trim(line):match "^[%w_][%w_%-%.]*"
+        if token then
+            table.insert(out, token)
+        end
+    end
+    return out
+end
+
 --- List available AVD names via `android emulator list`.
---- Assumes one AVD name per output line; blank lines are ignored.
+--- Output is parsed with parse_id_list so "name\tstatus" / decorative
+--- header lines / extra trailing metadata don't break the picker.
 ---@param callback fun(avds: string[])
 function M.list_avds(callback)
     local exe = resolve_binary()
@@ -116,14 +138,7 @@ function M.list_avds(callback)
                 callback {}
                 return
             end
-            local avds = {}
-            for line in (result.stdout or ""):gmatch "[^\r\n]+" do
-                local trimmed = vim.trim(line)
-                if #trimmed > 0 then
-                    table.insert(avds, trimmed)
-                end
-            end
-            callback(avds)
+            callback(parse_id_list(result.stdout))
         end)
     end)
 end
@@ -163,14 +178,7 @@ function M.list_emulator_profiles(callback)
                 callback {}
                 return
             end
-            local profiles = {}
-            for line in (result.stdout or ""):gmatch "[^\r\n]+" do
-                local trimmed = vim.trim(line)
-                if #trimmed > 0 then
-                    table.insert(profiles, trimmed)
-                end
-            end
-            callback(profiles)
+            callback(parse_id_list(result.stdout))
         end)
     end)
 end

--- a/lua/droid/commands.lua
+++ b/lua/droid/commands.lua
@@ -199,6 +199,57 @@ function M.setup_commands()
             end
         end)
     end, { nargs = "?", complete = "file", bang = true })
+
+    -- :DroidDocs <query>   search Android Knowledge Base, fetch picked result
+    vim.api.nvim_create_user_command("DroidDocs", function(opts)
+        local cli = require("droid.backends.android_cli")
+        if not cli.is_available() then
+            vim.notify(
+                "DroidDocs requires android-cli (`android` not on PATH). See :checkhealth droid.",
+                vim.log.levels.ERROR
+            )
+            return
+        end
+
+        local query = vim.trim(opts.args or "")
+        if query == "" then
+            vim.notify("Usage: :DroidDocs <query>", vim.log.levels.WARN)
+            return
+        end
+
+        cli.docs_search(query, function(results)
+            if #results == 0 then
+                vim.notify("No KB results for: " .. query, vim.log.levels.INFO)
+                return
+            end
+
+            vim.ui.select(results, {
+                prompt = "Android KB results:",
+                format_item = function(r)
+                    return r
+                end,
+            }, function(choice)
+                if not choice then
+                    return
+                end
+                local url = choice:match("kb://%S+") or choice
+                cli.docs_fetch(url, function(ok, body)
+                    if not ok then
+                        return
+                    end
+                    vim.cmd("new")
+                    local buf = vim.api.nvim_get_current_buf()
+                    vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(body, "\n", { plain = true }))
+                    vim.bo[buf].buftype = "nofile"
+                    vim.bo[buf].bufhidden = "wipe"
+                    vim.bo[buf].swapfile = false
+                    vim.bo[buf].filetype = "markdown"
+                    vim.bo[buf].modifiable = false
+                    vim.api.nvim_buf_set_name(buf, "droid-docs://" .. url)
+                end)
+            end)
+        end)
+    end, { nargs = "+" })
 end
 
 return M

--- a/lua/droid/commands.lua
+++ b/lua/droid/commands.lua
@@ -161,6 +161,44 @@ function M.setup_commands()
     vim.api.nvim_create_user_command("DroidMirror", function()
         android.mirror()
     end, {})
+
+    -- :DroidScreenshot [path]   capture device screen (android-cli)
+    -- :DroidScreenshot! [path]  capture with --annotate (labels UI elements)
+    vim.api.nvim_create_user_command("DroidScreenshot", function(opts)
+        local cli = require("droid.backends.android_cli")
+        if not cli.is_available() then
+            vim.notify(
+                "DroidScreenshot requires android-cli (`android` not on PATH). See :checkhealth droid.",
+                vim.log.levels.ERROR
+            )
+            return
+        end
+
+        local output = opts.fargs[1]
+        if not output or output == "" then
+            local stamp = os.date("%Y%m%d-%H%M%S")
+            output = vim.fs.joinpath(vim.fn.stdpath("cache"), ("droid-screenshot-%s.png"):format(stamp))
+        end
+
+        cli.screen_capture({ output = output, annotate = opts.bang }, function(ok, path)
+            if not ok then
+                return
+            end
+            vim.notify("Screenshot saved: " .. path, vim.log.levels.INFO)
+
+            local opener
+            if vim.fn.has("mac") == 1 then
+                opener = "open"
+            elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+                opener = "explorer"
+            elseif vim.fn.executable("xdg-open") == 1 then
+                opener = "xdg-open"
+            end
+            if opener then
+                vim.system({ opener, path }, { detach = true })
+            end
+        end)
+    end, { nargs = "?", complete = "file", bang = true })
 end
 
 return M

--- a/lua/droid/commands.lua
+++ b/lua/droid/commands.lua
@@ -165,7 +165,7 @@ function M.setup_commands()
     -- :DroidScreenshot [path]   capture device screen (android-cli)
     -- :DroidScreenshot! [path]  capture with --annotate (labels UI elements)
     vim.api.nvim_create_user_command("DroidScreenshot", function(opts)
-        local cli = require("droid.backends.android_cli")
+        local cli = require "droid.backends.android_cli"
         if not cli.is_available() then
             vim.notify(
                 "DroidScreenshot requires android-cli (`android` not on PATH). See :checkhealth droid.",
@@ -176,8 +176,8 @@ function M.setup_commands()
 
         local output = opts.fargs[1]
         if not output or output == "" then
-            local stamp = os.date("%Y%m%d-%H%M%S")
-            output = vim.fs.joinpath(vim.fn.stdpath("cache"), ("droid-screenshot-%s.png"):format(stamp))
+            local stamp = os.date "%Y%m%d-%H%M%S"
+            output = vim.fs.joinpath(vim.fn.stdpath "cache", ("droid-screenshot-%s.png"):format(stamp))
         end
 
         cli.screen_capture({ output = output, annotate = opts.bang }, function(ok, path)
@@ -187,11 +187,11 @@ function M.setup_commands()
             vim.notify("Screenshot saved: " .. path, vim.log.levels.INFO)
 
             local opener
-            if vim.fn.has("mac") == 1 then
+            if vim.fn.has "mac" == 1 then
                 opener = "open"
-            elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+            elseif vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
                 opener = "explorer"
-            elseif vim.fn.executable("xdg-open") == 1 then
+            elseif vim.fn.executable "xdg-open" == 1 then
                 opener = "xdg-open"
             end
             if opener then
@@ -202,7 +202,7 @@ function M.setup_commands()
 
     -- :DroidDocs <query>   search Android Knowledge Base, fetch picked result
     vim.api.nvim_create_user_command("DroidDocs", function(opts)
-        local cli = require("droid.backends.android_cli")
+        local cli = require "droid.backends.android_cli"
         if not cli.is_available() then
             vim.notify(
                 "DroidDocs requires android-cli (`android` not on PATH). See :checkhealth droid.",
@@ -232,12 +232,12 @@ function M.setup_commands()
                 if not choice then
                     return
                 end
-                local url = choice:match("kb://%S+") or choice
+                local url = choice:match "kb://%S+" or choice
                 cli.docs_fetch(url, function(ok, body)
                     if not ok then
                         return
                     end
-                    vim.cmd("new")
+                    vim.cmd "new"
                     local buf = vim.api.nvim_get_current_buf()
                     vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(body, "\n", { plain = true }))
                     vim.bo[buf].buftype = "nofile"

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -74,16 +74,15 @@ local defaults = {
         -- backend still only fires when a prefer_for flag below opts a
         -- capability into it.
         enabled = "auto",
-        -- All silent-reroute capabilities default to false so installing
-        -- android-cli never changes existing behavior without the user
-        -- opting in. :DroidScreenshot and :DroidDocs are explicit CLI-only
-        -- commands and bypass this table; the flags here are informational
-        -- for them and consulted by :checkhealth droid.
+        -- prefer_for governs capabilities that have BOTH a legacy path
+        -- (adb/avdmanager/gradle) and a CLI path. Defaults are off so
+        -- installing android-cli never changes existing behavior without
+        -- the user opting in. CLI-only commands (:DroidScreenshot,
+        -- :DroidDocs) are not listed here -- they always use the CLI when
+        -- available.
         prefer_for = {
             emulator = false, -- emulator list/start/stop/create
             deploy = false, -- `android run --apks=…` instead of gradle install + am start
-            screenshot = true, -- informational; :DroidScreenshot always uses CLI
-            docs = true, -- informational; :DroidDocs always uses CLI
         },
     },
 }

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -70,12 +70,20 @@ local defaults = {
         logcat_startup_delay_ms = 2000,
     },
     android_cli = {
-        enabled = "auto", -- "auto" | true | false ("auto" = use when `android` is on PATH)
+        -- "auto" | true | false. "auto" detects `android` on PATH; the
+        -- backend still only fires when a prefer_for flag below opts a
+        -- capability into it.
+        enabled = "auto",
+        -- All silent-reroute capabilities default to false so installing
+        -- android-cli never changes existing behavior without the user
+        -- opting in. :DroidScreenshot and :DroidDocs are explicit CLI-only
+        -- commands and bypass this table; the flags here are informational
+        -- for them and consulted by :checkhealth droid.
         prefer_for = {
-            emulator = true, -- emulator list/start/stop/create
+            emulator = false, -- emulator list/start/stop/create
             deploy = false, -- `android run --apks=…` instead of gradle install + am start
-            screenshot = true, -- `android screen capture`
-            docs = true, -- `android docs search/fetch`
+            screenshot = true, -- informational; :DroidScreenshot always uses CLI
+            docs = true, -- informational; :DroidDocs always uses CLI
         },
     },
 }

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -69,6 +69,15 @@ local defaults = {
         boot_check_interval_ms = 3000,
         logcat_startup_delay_ms = 2000,
     },
+    android_cli = {
+        enabled = "auto", -- "auto" | true | false ("auto" = use when `android` is on PATH)
+        prefer_for = {
+            emulator = true, -- emulator list/start/stop/create
+            deploy = false, -- `android run --apks=…` instead of gradle install + am start
+            screenshot = true, -- `android screen capture`
+            docs = true, -- `android docs search/fetch`
+        },
+    },
 }
 
 M.config = vim.deepcopy(defaults)

--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -5,6 +5,52 @@ local M = {}
 
 M.selected_variant = "Debug"
 
+--- Glob APKs produced by `assemble<Variant>` under the standard AGP layout.
+--- Matches `*/build/outputs/apk/<variantLower>/*.apk` -- covers single-
+--- module debug/release projects. Flavored builds (variant dir like
+--- `freeDebug`) are not auto-detected; users with flavors should keep
+--- config.android_cli.prefer_for.deploy = false.
+---@param cwd string project root
+---@param variant string e.g. "Debug" or "Release"
+---@return string[] absolute APK paths
+local function find_apks_for_variant(cwd, variant)
+    local pattern = vim.fs.joinpath(cwd, "*", "build", "outputs", "apk", variant:lower(), "*.apk")
+    return vim.fn.glob(pattern, false, true)
+end
+
+--- Deploy via android-cli when preferred; returns true if the CLI path
+--- handled the deploy (the caller should not invoke gradle install task).
+---@param g { cwd: string }
+---@param callback fun(success: boolean, exit_code: number, message: string)
+---@return boolean handled
+local function try_cli_deploy(g, callback)
+    local cli = require("droid.backends.android_cli")
+    if not cli.prefers("deploy") then
+        return false
+    end
+
+    local apks = find_apks_for_variant(g.cwd, M.selected_variant)
+    if #apks == 0 then
+        local msg = ("No APKs found for variant %s under */build/outputs/apk/%s/"):format(
+            M.selected_variant,
+            M.selected_variant:lower()
+        )
+        vim.notify(msg, vim.log.levels.ERROR)
+        vim.schedule(function()
+            callback(false, -1, msg)
+        end)
+        return true
+    end
+
+    progress.update_spinner_message("Deploying via android-cli")
+    cli.run_apks(apks, {}, function(ok, detail)
+        local message = ok and "Installed via android-cli" or ("android-cli run failed: " .. detail)
+        vim.notify(message, ok and vim.log.levels.INFO or vim.log.levels.ERROR)
+        callback(ok, ok and 0 or 1, message)
+    end)
+    return true
+end
+
 local function find_gradlew()
     local gradlew = vim.fs.find("gradlew", { upward = true })[1]
     if gradlew and vim.fn.executable(gradlew) == 1 then
@@ -221,8 +267,18 @@ function M.install(callback)
         return
     end
 
-    local task = "install" .. M.selected_variant
     progress.start_spinner("Installing " .. M.selected_variant .. " APK")
+
+    if try_cli_deploy(g, function(ok, code, message)
+        progress.stop_spinner()
+        if callback then
+            callback(ok, code, message)
+        end
+    end) then
+        return
+    end
+
+    local task = "install" .. M.selected_variant
 
     local buf = buffer.get_or_create("gradle", nil)
 
@@ -297,6 +353,15 @@ function M.build_and_install(callback)
         end
 
         progress.update_spinner_message("Installing " .. M.selected_variant .. " APK")
+
+        if try_cli_deploy(g, function(ok, code, message)
+            progress.stop_spinner()
+            if callback then
+                callback(ok, code, message, "install")
+            end
+        end) then
+            return
+        end
 
         local buf = buffer.get_or_create("gradle", nil)
 

--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -5,17 +5,27 @@ local M = {}
 
 M.selected_variant = "Debug"
 
---- Glob APKs produced by `assemble<Variant>` under the standard AGP layout.
---- Matches `*/build/outputs/apk/<variantLower>/*.apk` -- covers single-
---- module debug/release projects. Flavored builds (variant dir like
---- `freeDebug`) are not auto-detected; callers should fall back to the
---- gradle install path when this returns empty.
+--- Locate APKs produced by `assemble<Variant>` under the standard AGP
+--- output layout. Handles both:
+---   - default builds: */build/outputs/apk/<variantLower>/*.apk
+---   - flavored builds: */build/outputs/apk/<flavor><Variant>/*.apk
+---     (e.g. freeDebug, paidRelease)
+--- An APK is considered a match when its parent directory name either
+--- equals variant:lower() or ends with the variant in its camelCase form.
 ---@param cwd string project root
 ---@param variant string e.g. "Debug" or "Release"
 ---@return string[] absolute APK paths
 function M.find_apks_for_variant(cwd, variant)
-    local pattern = vim.fs.joinpath(cwd, "*", "build", "outputs", "apk", variant:lower(), "*.apk")
-    return vim.fn.glob(pattern, false, true)
+    local lower = variant:lower()
+    local pattern = vim.fs.joinpath(cwd, "*", "build", "outputs", "apk", "*", "*.apk")
+    local matches = {}
+    for _, apk in ipairs(vim.fn.glob(pattern, false, true)) do
+        local dir = vim.fs.basename(vim.fs.dirname(apk))
+        if dir == lower or (dir:sub(-#variant) == variant and #dir > #variant) then
+            table.insert(matches, apk)
+        end
+    end
+    return matches
 end
 
 --- Locate gradlew without notifying on failure -- for callers that want

--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -8,47 +8,20 @@ M.selected_variant = "Debug"
 --- Glob APKs produced by `assemble<Variant>` under the standard AGP layout.
 --- Matches `*/build/outputs/apk/<variantLower>/*.apk` -- covers single-
 --- module debug/release projects. Flavored builds (variant dir like
---- `freeDebug`) are not auto-detected; users with flavors should keep
---- config.android_cli.prefer_for.deploy = false.
+--- `freeDebug`) are not auto-detected; callers should fall back to the
+--- gradle install path when this returns empty.
 ---@param cwd string project root
 ---@param variant string e.g. "Debug" or "Release"
 ---@return string[] absolute APK paths
-local function find_apks_for_variant(cwd, variant)
+function M.find_apks_for_variant(cwd, variant)
     local pattern = vim.fs.joinpath(cwd, "*", "build", "outputs", "apk", variant:lower(), "*.apk")
     return vim.fn.glob(pattern, false, true)
 end
 
---- Deploy via android-cli when preferred; returns true if the CLI path
---- handled the deploy (the caller should not invoke gradle install task).
----@param g { cwd: string }
----@param callback fun(success: boolean, exit_code: number, message: string)
----@return boolean handled
-local function try_cli_deploy(g, callback)
-    local cli = require("droid.backends.android_cli")
-    if not cli.prefers("deploy") then
-        return false
-    end
-
-    local apks = find_apks_for_variant(g.cwd, M.selected_variant)
-    if #apks == 0 then
-        local msg = ("No APKs found for variant %s under */build/outputs/apk/%s/"):format(
-            M.selected_variant,
-            M.selected_variant:lower()
-        )
-        vim.notify(msg, vim.log.levels.ERROR)
-        vim.schedule(function()
-            callback(false, -1, msg)
-        end)
-        return true
-    end
-
-    progress.update_spinner_message("Deploying via android-cli")
-    cli.run_apks(apks, {}, function(ok, detail)
-        local message = ok and "Installed via android-cli" or ("android-cli run failed: " .. detail)
-        vim.notify(message, ok and vim.log.levels.INFO or vim.log.levels.ERROR)
-        callback(ok, ok and 0 or 1, message)
-    end)
-    return true
+--- Locate gradlew without notifying on failure -- for callers that want
+--- to handle "not found" themselves.
+function M.find_gradlew()
+    return find_gradlew()
 end
 
 local function find_gradlew()
@@ -267,18 +240,8 @@ function M.install(callback)
         return
     end
 
-    progress.start_spinner("Installing " .. M.selected_variant .. " APK")
-
-    if try_cli_deploy(g, function(ok, code, message)
-        progress.stop_spinner()
-        if callback then
-            callback(ok, code, message)
-        end
-    end) then
-        return
-    end
-
     local task = "install" .. M.selected_variant
+    progress.start_spinner("Installing " .. M.selected_variant .. " APK")
 
     local buf = buffer.get_or_create("gradle", nil)
 
@@ -353,15 +316,6 @@ function M.build_and_install(callback)
         end
 
         progress.update_spinner_message("Installing " .. M.selected_variant .. " APK")
-
-        if try_cli_deploy(g, function(ok, code, message)
-            progress.stop_spinner()
-            if callback then
-                callback(ok, code, message, "install")
-            end
-        end) then
-            return
-        end
 
         local buf = buffer.get_or_create("gradle", nil)
 

--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -200,7 +200,7 @@ function M.build(on_complete)
             vim.notify(string.format("Build failed (exit code: %d)", exit_code), vim.log.levels.ERROR)
         end
         if on_complete then
-            on_complete()
+            on_complete(success)
         end
     end)
 end

--- a/lua/droid/health.lua
+++ b/lua/droid/health.lua
@@ -6,15 +6,15 @@
 local M = {}
 
 local function check_android_cli()
-    vim.health.start("droid.nvim: android-cli backend")
+    vim.health.start "droid.nvim: android-cli backend"
 
-    local cli = require("droid.backends.android_cli")
+    local cli = require "droid.backends.android_cli"
     cli.reset_cache() -- always re-probe inside checkhealth
 
     local cfg = (require("droid.config").get() or {}).android_cli or {}
     vim.health.info("config.enabled = " .. vim.inspect(cfg.enabled))
 
-    local exe = vim.fn.exepath("android")
+    local exe = vim.fn.exepath "android"
     if exe == "" then
         vim.health.warn(
             "`android` binary not found on PATH",
@@ -25,9 +25,7 @@ local function check_android_cli()
     end
 
     if cfg.enabled == false then
-        vim.health.warn(
-            "android-cli detected at " .. exe .. " but disabled via config.android_cli.enabled = false"
-        )
+        vim.health.warn("android-cli detected at " .. exe .. " but disabled via config.android_cli.enabled = false")
         return
     end
 
@@ -43,7 +41,7 @@ local function check_android_cli()
     for _, cap in ipairs(capabilities) do
         local routed = cli.prefers(cap)
         local note = routed and "routed through android-cli" or "using fallback path"
-        if cap == "emulator" and (vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1) then
+        if cap == "emulator" and (vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1) then
             note = "fallback only (android emulator is not supported on Windows)"
         end
         vim.health.info(("%-10s -> %s (prefer_for.%s = %s)"):format(cap, note, cap, tostring(prefer_for[cap])))
@@ -51,9 +49,9 @@ local function check_android_cli()
 end
 
 local function check_sdk_tools()
-    vim.health.start("droid.nvim: Android SDK tools (fallback path)")
+    vim.health.start "droid.nvim: Android SDK tools (fallback path)"
 
-    local android = require("droid.android")
+    local android = require "droid.android"
     local sdk = android.detect_android_sdk()
     if not sdk then
         vim.health.error(

--- a/lua/droid/health.lua
+++ b/lua/droid/health.lua
@@ -37,8 +37,7 @@ local function check_android_cli()
     vim.health.ok(("android-cli available: %s (%s)"):format(cli.version() or "version unknown", exe))
 
     local prefer_for = cfg.prefer_for or {}
-    local capabilities = { "emulator", "deploy", "screenshot", "docs" }
-    for _, cap in ipairs(capabilities) do
+    for _, cap in ipairs { "emulator", "deploy" } do
         local routed = cli.prefers(cap)
         local note = routed and "routed through android-cli" or "using fallback path"
         if cap == "emulator" and (vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1) then
@@ -46,6 +45,8 @@ local function check_android_cli()
         end
         vim.health.info(("%-10s -> %s (prefer_for.%s = %s)"):format(cap, note, cap, tostring(prefer_for[cap])))
     end
+
+    vim.health.info "CLI-only commands available: :DroidScreenshot, :DroidDocs"
 end
 
 local function check_sdk_tools()

--- a/lua/droid/health.lua
+++ b/lua/droid/health.lua
@@ -1,0 +1,87 @@
+--- `:checkhealth droid` entry point.
+--- Surfaces the state of the android-cli backend and the legacy SDK tools
+--- that the fallback path depends on. Intentionally light -- LSP server
+--- diagnostics live with the LSP modules, not here.
+
+local M = {}
+
+local function check_android_cli()
+    vim.health.start("droid.nvim: android-cli backend")
+
+    local cli = require("droid.backends.android_cli")
+    cli.reset_cache() -- always re-probe inside checkhealth
+
+    local cfg = (require("droid.config").get() or {}).android_cli or {}
+    vim.health.info("config.enabled = " .. vim.inspect(cfg.enabled))
+
+    local exe = vim.fn.exepath("android")
+    if exe == "" then
+        vim.health.warn(
+            "`android` binary not found on PATH",
+            "Install android-cli from https://developer.android.com/tools/agents to enable the new backend. "
+                .. "droid-nvim will keep using the existing adb/avdmanager paths."
+        )
+        return
+    end
+
+    if cfg.enabled == false then
+        vim.health.warn(
+            "android-cli detected at " .. exe .. " but disabled via config.android_cli.enabled = false"
+        )
+        return
+    end
+
+    if not cli.is_available() then
+        vim.health.error("`" .. exe .. " -V` failed; binary present but not functional")
+        return
+    end
+
+    vim.health.ok(("android-cli available: %s (%s)"):format(cli.version() or "version unknown", exe))
+
+    local prefer_for = cfg.prefer_for or {}
+    local capabilities = { "emulator", "deploy", "screenshot", "docs" }
+    for _, cap in ipairs(capabilities) do
+        local routed = cli.prefers(cap)
+        local note = routed and "routed through android-cli" or "using fallback path"
+        if cap == "emulator" and (vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1) then
+            note = "fallback only (android emulator is not supported on Windows)"
+        end
+        vim.health.info(("%-10s -> %s (prefer_for.%s = %s)"):format(cap, note, cap, tostring(prefer_for[cap])))
+    end
+end
+
+local function check_sdk_tools()
+    vim.health.start("droid.nvim: Android SDK tools (fallback path)")
+
+    local android = require("droid.android")
+    local sdk = android.detect_android_sdk()
+    if not sdk then
+        vim.health.error(
+            "Android SDK not detected",
+            "Set $ANDROID_HOME, vim.g.android_sdk, or config.android.android_home"
+        )
+        return
+    end
+    vim.health.ok("SDK: " .. sdk)
+
+    local function check_tool(label, path)
+        if not path then
+            vim.health.warn(label .. ": path could not be resolved")
+        elseif vim.fn.executable(path) == 1 then
+            vim.health.ok(label .. ": " .. path)
+        else
+            vim.health.warn(label .. ": not executable at " .. path)
+        end
+    end
+
+    check_tool("adb", android.get_adb_path())
+    check_tool("emulator", android.get_emulator_path())
+    check_tool("avdmanager", android.get_avdmanager_path())
+end
+
+function M.check()
+    check_android_cli()
+    check_sdk_tools()
+end
+
+return M


### PR DESCRIPTION
## Summary
Adds an optional [android-cli](https://developer.android.com/tools/agents/android-cli) backend behind feature flags. When the `android` binary is on PATH and the user opts in, droid-nvim routes select operations through it; otherwise the existing adb/avdmanager/gradle paths run unchanged. Defaults are conservative — installing android-cli alongside droid-nvim does not change any existing behavior until the user flips a flag.

- New module `lua/droid/backends/android_cli.lua` — detection, version cache, per-capability `prefers()` gate, wrappers for `emulator list/start/stop/create`, `run --apks`, `screen capture`, `docs search/fetch`.
- New config block `android_cli = { enabled = "auto", prefer_for = { emulator = false, deploy = false } }`.
- Wired into `:DroidEmulator` / `:DroidEmulatorStop` / `:DroidEmulatorCreate` (when `prefer_for.emulator = true`) and `:DroidRun` (when `prefer_for.deploy = true`, install + launch fused into a single `android run` call).
- `:DroidInstall` is intentionally untouched — `android run` cannot install-without-launching, so it always uses the gradle path.
- Two new CLI-only commands: `:DroidScreenshot[!] [path]` and `:DroidDocs <query>`.
- `:checkhealth droid` reports binary detection, version, per-capability routing, and SDK tool presence.
- APK discovery for the deploy path handles default (`debug/`, `release/`) and flavored (`freeDebug/`, `paidRelease/`) AGP output layouts, with graceful fallback to `gradle install<Variant>` if nothing matches.

## Behavior matrix (default config)
| Command | `android` not installed | `android` installed |
|---|---|---|
| `:DroidEmulator*` | unchanged | **unchanged** (opt in via `prefer_for.emulator`) |
| `:DroidRun` / `:DroidInstall` | unchanged | **unchanged** (opt in via `prefer_for.deploy`) |
| `:DroidScreenshot` | errors with pointer to `:checkhealth droid` | works |
| `:DroidDocs <q>` | errors with pointer | works |

## Implementation notes
- All subprocess calls use `vim.system` (no `vim.fn.jobstart` / `vim.fn.systemlist`) — Neovim 0.12-ready.
- Output parsers (`emulator list`, `--list-profiles`) take the first identifier-shaped token per line; tolerant of `name<tab>status` style metadata. Docs-search URL extraction uses `kb://%S+` regex so it's robust to `title — url` formats.
- `android emulator` is unsupported on Windows; the `emulator` capability auto-disables there even if `prefer_for.emulator = true`.
- `cli.is_available()` caches result; `:checkhealth droid` resets the cache so environment changes show immediately.
- `stylua --check lua` passes.

## Test plan
- [x] `:checkhealth droid` with `android` not installed → SDK section healthy, backend section warns with install URL.
- [x] `:checkhealth droid` with `android` installed → backend section ok, version printed, prefer_for shows `false` defaults.
- [x] Default config: `:DroidEmulator`, `:DroidRun`, `:DroidInstall` behave exactly as before installing this change.
- [x] Set `prefer_for.emulator = true` → `:DroidEmulator`, `:DroidEmulatorStop`, `:DroidEmulatorCreate` use the CLI; AVD picker populates from `android emulator list`.
- [x] Set `prefer_for.deploy = true` → `:DroidRun` builds via gradle, then deploys + launches in one `android run` call (no double-launch); `:DroidInstall` still uses gradle and does not launch.
- [x] Flavored project with `prefer_for.deploy = true` → APK is found under `app/build/outputs/apk/<flavor><Variant>/` and deployed.
- [x] `:DroidScreenshot` → PNG saved under `stdpath('cache')`, opens with OS default viewer.
- [x] `:DroidScreenshot!` → annotated capture (labels `#1`, `#2`, …).
- [x] `:DroidDocs jetpack compose` → picker of `kb://` results; pick one → markdown buffer with fetched body.
- [x] Windows: emulator capability remains on legacy path even when `prefer_for.emulator = true`; `:checkhealth droid` calls this out.