### PR TITLE
fix(lsp): use client:supports_method to silence Neovim 0.11 deprecation

### DIFF
--- a/lua/droid/lsp/java/init.lua
+++ b/lua/droid/lsp/java/init.lua
@@ -250,7 +250,7 @@ function M.start(cfg)
             group = vim.api.nvim_create_augroup("DroidJavaInlayHints", { clear = true }),
             callback = function(ev)
                 local c = vim.lsp.get_client_by_id(ev.data.client_id)
-                if c and c.name == "jdtls" and c.supports_method "textDocument/inlayHint" then
+                if c and c.name == "jdtls" and c:supports_method "textDocument/inlayHint" then
                     vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
                 end
             end,

--- a/lua/droid/lsp/kotlin/init.lua
+++ b/lua/droid/lsp/kotlin/init.lua
@@ -313,7 +313,7 @@ function M.start(cfg)
             group = vim.api.nvim_create_augroup("DroidKotlinInlayHints", { clear = true }),
             callback = function(ev)
                 local c = vim.lsp.get_client_by_id(ev.data.client_id)
-                if c and c.name == "kotlin_ls" and c.supports_method "textDocument/inlayHint" then
+                if c and c.name == "kotlin_ls" and c:supports_method "textDocument/inlayHint" then
                     vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
                 end
             end,


### PR DESCRIPTION
## Summary
Neovim 0.11 deprecated the dot-call form `client.supports_method(method)` in favor of the method-call form `client:supports_method(method)` which passes `self`. Users see the warning surfaced via `:checkhealth vim.deprecated`. Two sites updated (jdtls and kotlin_ls inlay-hint guards); semantics unchanged.

## Test plan
- [x] `:checkhealth vim.deprecated` no longer reports `client.supports_method` from droid.nvim
- [x] Open a Kotlin file with kotlin-lsp attached — inlay hints still enable
- [x] Open a Java file with jdtls attached — inlay hints still enable