### PR TITLE
feat: flatten android_cli config — single auto/true/false toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,20 +143,12 @@ require("droid").setup({
         android_home = nil,                -- override ANDROID_HOME env var
         android_avd_home = nil,            -- override ANDROID_AVD_HOME env var
     },
-    android_cli = {
-        -- "auto" detects the `android` binary on PATH; set to false to
-        -- disable the backend even if installed.
-        enabled = "auto",
-        -- Opt-in flags for capabilities that have both a legacy and a
-        -- CLI path. Defaults are off so installing android-cli never
-        -- changes existing behavior until you flip a flag. The CLI-only
-        -- commands :DroidScreenshot and :DroidDocs always use the CLI
-        -- when available and are not listed here.
-        prefer_for = {
-            emulator = false,              -- :DroidEmulator / Stop / Create
-            deploy = false,                -- :DroidRun uses `android run` (install + launch)
-        },
-    },
+    -- android-cli backend. "auto" uses the `android` binary if on PATH,
+    -- true forces it (warns when missing), false disables it entirely.
+    -- When active, droid-nvim routes emulator management, :DroidRun
+    -- deploy, screenshots, and KB docs through android-cli. :DroidInstall
+    -- stays on gradle (android run cannot install without launching).
+    android_cli = "auto",
 })
 ```
 
@@ -275,9 +267,9 @@ These commands require the [`android` CLI](https://developer.android.com/tools/a
 | `:DroidScreenshot! [path]` | Capture with `--annotate` (labels UI elements `#1`, `#2`, …) |
 | `:DroidDocs <query>` | Search the Android Knowledge Base; pick a result to open it in a read-only markdown buffer |
 
-When `android_cli.prefer_for.emulator = true`, the emulator commands (`:DroidEmulator`, `:DroidEmulatorStop`, `:DroidEmulatorCreate`) route through `android emulator …`. When `android_cli.prefer_for.deploy = true`, `:DroidRun` uses `android run --apks=…` (install + launch fused into a single call) instead of `gradle install<Variant>` + `am start`. `:DroidInstall` always uses the legacy gradle path.
+When `android_cli` is active (default `"auto"` + `android` on PATH), the emulator commands (`:DroidEmulator`, `:DroidEmulatorStop`, `:DroidEmulatorCreate`) route through `android emulator …`, and `:DroidRun` uses `android run --apks=…` (install + launch fused into a single call) instead of `gradle install<Variant>` + `am start`. `:DroidInstall` always uses the legacy gradle path because `android run` cannot install without launching.
 
-> **Note:** `android emulator` is not supported on Windows; the `emulator` capability auto-falls-back to `avdmanager`/`emulator` there even when `prefer_for.emulator = true`.
+> **Note:** `android emulator` is not supported on Windows; the emulator commands fall back to `avdmanager`/`emulator` there even when `android_cli` is active.
 
 ### Logcat
 

--- a/lua/droid/backends/android_cli.lua
+++ b/lua/droid/backends/android_cli.lua
@@ -1,9 +1,10 @@
 --- android-cli backend wrapper.
 --- Detects the `android` binary on PATH and exposes typed helpers for the
---- subset of commands droid-nvim cares about. All callers must gate on
---- `M.is_available()` and respect `config.android_cli.prefer_for.<capability>`
---- before routing through here -- existing adb/avdmanager paths remain the
---- fallback whenever this backend is disabled, unavailable, or not preferred.
+--- subset of commands droid-nvim cares about. Callers gate on
+--- `M.prefers(capability)`, which combines availability with the
+--- top-level config.android_cli setting ("auto" | true | false) and the
+--- per-capability quirks (e.g. `emulator` is unsupported on Windows so
+--- the fallback path always wins there).
 
 local M = {}
 
@@ -24,16 +25,35 @@ function M.reset_cache()
     _cached_version = nil
 end
 
---- Resolve the `android` executable path, honoring the user `enabled` setting.
----@return string|nil path nil when disabled or not found
+--- Read the top-level android_cli toggle. Legacy table form
+--- `{ enabled = ... }` is accepted for backward compatibility.
+---@return "auto"|boolean
+local function read_toggle()
+    local raw = config.get().android_cli
+    if type(raw) == "table" then
+        return raw.enabled
+    end
+    return raw
+end
+
+--- Resolve the `android` executable path, honoring the user toggle.
+--- Returns nil when the toggle is false or when the binary is absent.
+--- When the toggle is `true` and the binary is missing we warn once.
+---@return string|nil
 local function resolve_binary()
-    local cfg = config.get().android_cli or {}
-    if cfg.enabled == false then
+    local toggle = read_toggle()
+    if toggle == false then
         return nil
     end
 
     local exe = vim.fn.exepath "android"
     if exe == nil or exe == "" then
+        if toggle == true then
+            vim.notify(
+                'config.android_cli = true but `android` binary not found on PATH; install from https://developer.android.com/tools/agents or set android_cli = "auto".',
+                vim.log.levels.WARN
+            )
+        end
         return nil
     end
     return exe
@@ -74,9 +94,8 @@ function M.version()
 end
 
 --- Check whether a specific capability should be routed through android-cli.
---- Returns false when the backend is unavailable, disabled, or the
---- capability flag is off. Also auto-disables `emulator` on Windows where
---- `android emulator` is not supported.
+--- True when the backend is available and the capability has no
+--- platform-specific blocker (currently: `emulator` on Windows).
 ---@param capability "emulator"|"deploy"
 ---@return boolean
 function M.prefers(capability)
@@ -86,9 +105,7 @@ function M.prefers(capability)
     if capability == "emulator" and is_windows() then
         return false
     end
-    local cfg = config.get().android_cli or {}
-    local prefer_for = cfg.prefer_for or {}
-    return prefer_for[capability] == true
+    return true
 end
 
 local function notify_failure(action, result)

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -69,22 +69,13 @@ local defaults = {
         boot_check_interval_ms = 3000,
         logcat_startup_delay_ms = 2000,
     },
-    android_cli = {
-        -- "auto" | true | false. "auto" detects `android` on PATH; the
-        -- backend still only fires when a prefer_for flag below opts a
-        -- capability into it.
-        enabled = "auto",
-        -- prefer_for governs capabilities that have BOTH a legacy path
-        -- (adb/avdmanager/gradle) and a CLI path. Defaults are off so
-        -- installing android-cli never changes existing behavior without
-        -- the user opting in. CLI-only commands (:DroidScreenshot,
-        -- :DroidDocs) are not listed here -- they always use the CLI when
-        -- available.
-        prefer_for = {
-            emulator = false, -- emulator list/start/stop/create
-            deploy = false, -- `android run --apks=…` instead of gradle install + am start
-        },
-    },
+    -- android-cli backend. "auto" uses the `android` binary if it's on
+    -- PATH; true forces it on (errors when unavailable); false disables
+    -- it entirely. When active, droid-nvim routes emulator management,
+    -- :DroidRun deploy, screenshots, and KB docs through android-cli.
+    -- :DroidInstall stays on the gradle path either way (android run
+    -- cannot install without launching).
+    android_cli = "auto",
 }
 
 M.config = vim.deepcopy(defaults)

--- a/lua/droid/health.lua
+++ b/lua/droid/health.lua
@@ -11,8 +11,9 @@ local function check_android_cli()
     local cli = require "droid.backends.android_cli"
     cli.reset_cache() -- always re-probe inside checkhealth
 
-    local cfg = (require("droid.config").get() or {}).android_cli or {}
-    vim.health.info("config.enabled = " .. vim.inspect(cfg.enabled))
+    local raw = (require "droid.config").get().android_cli
+    local toggle = type(raw) == "table" and raw.enabled or raw
+    vim.health.info("config.android_cli = " .. vim.inspect(toggle))
 
     local exe = vim.fn.exepath "android"
     if exe == "" then
@@ -24,8 +25,8 @@ local function check_android_cli()
         return
     end
 
-    if cfg.enabled == false then
-        vim.health.warn("android-cli detected at " .. exe .. " but disabled via config.android_cli.enabled = false")
+    if toggle == false then
+        vim.health.warn("android-cli detected at " .. exe .. " but disabled via config.android_cli = false")
         return
     end
 
@@ -36,14 +37,13 @@ local function check_android_cli()
 
     vim.health.ok(("android-cli available: %s (%s)"):format(cli.version() or "version unknown", exe))
 
-    local prefer_for = cfg.prefer_for or {}
     for _, cap in ipairs { "emulator", "deploy" } do
         local routed = cli.prefers(cap)
         local note = routed and "routed through android-cli" or "using fallback path"
         if cap == "emulator" and (vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1) then
             note = "fallback only (android emulator is not supported on Windows)"
         end
-        vim.health.info(("%-10s -> %s (prefer_for.%s = %s)"):format(cap, note, cap, tostring(prefer_for[cap])))
+        vim.health.info(("%-10s -> %s"):format(cap, note))
     end
 
     vim.health.info "CLI-only commands available: :DroidScreenshot, :DroidDocs"


### PR DESCRIPTION
## Summary
Replaces the nested `{ enabled, prefer_for = { emulator, deploy } }` table with one top-level value:

```lua
android_cli = "auto"  -- use android-cli if on PATH (default)
android_cli = true    -- force; warn if missing
android_cli = false   -- disable
```

When active, droid-nvim automatically routes emulator management and `:DroidRun` deploy through android-cli — no per-capability opt-in. The Windows emulator carve-out stays (since `android emulator` isn't supported there). `:DroidInstall` and the CLI-only `:DroidScreenshot`/`:DroidDocs` commands are unaffected.

## Behavior change
With default config + `android` installed, the moment this lands:
- `:DroidEmulator` / `:DroidEmulatorStop` / `:DroidEmulatorCreate` route through android-cli
- `:DroidRun` uses `android run --apks=…` (install + launch fused)

This is the inverse of the previous conservative default. Users who want the old behavior set `android_cli = false`.

## Backward compatibility
The backend still accepts the legacy `{ enabled = ... }` table shape so existing user configs don't break on upgrade.

## Test plan
- [x] `:checkhealth droid` with default config + `android` on PATH → ok, both capabilities routed
- [x] `:checkhealth droid` with `android_cli = false` → warn, both capabilities use fallback
- [x] `:checkhealth droid` with `android_cli = true` but `android` missing → warn at next run
- [x] Legacy config `android_cli = { enabled = "auto" }` still works
- [x] Windows: emulator capability stays on fallback even when `android_cli = "auto"` succeeds