### PR TITLE
feat(editor): Kotlin indentation restore, :DroidKdoc, and file templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,41 @@ The adapter starts the kotlin-lsp debug server and resolves classpath, the Java
 executable, and the main-class location automatically. Requires `kotlin_ls` to
 be attached.
 
+### Editor experience (Kotlin)
+
+Small quality-of-life features for editing `.kt` buffers. Everything below is on
+by default and configured under the `editor` group:
+
+```lua
+editor = {
+  indent = true,          -- restore Neovim's built-in Kotlin indenter
+  file_templates = true,  -- offer scaffolds when creating an empty .kt file
+  templates = {},         -- extra file templates (merged with the built-ins)
+}
+```
+
+#### Indentation
+
+droid does not ship its own indenter. Neovim already bundles
+`indent/kotlin.vim` (`GetKotlinIndent`), and droid's `after/ftplugin/kotlin.lua`
+simply restores `GetKotlinIndent()` as `indentexpr` when another plugin
+(typically nvim-treesitter's unmaintained indent module) has overridden it. Set
+`editor.indent = false` to opt out.
+
+#### `:DroidKdoc`
+
+Generates a `/** … */` KDoc stub — with `@param` and `@return` tags — for the
+Kotlin function under the cursor. Uses treesitter when available and falls back
+to a regex parser otherwise.
+
+#### File templates
+
+Creating a new, empty `.kt` file offers a picker of scaffolds — Class,
+Interface, Data class, Object, Enum, and Sealed class — with the package and
+type name interpolated by the language server. Add your own via
+`editor.templates` (merged with the built-ins), or disable the feature with
+`editor.file_templates = false`.
+
 ## Commands
 
 ### Workflow
@@ -347,6 +382,7 @@ These commands work in `.kt`, `.java`, and `.groovy` buffers with their respecti
 | `:DroidHintsToggle` | Toggle HINT-severity diagnostics |
 | `:DroidLspRefresh` | Reload the Kotlin LSP workspace (re-import project model) |
 | `:DroidLspLog` | Open the Kotlin LSP project-sync log |
+| `:DroidKdoc` | Generate a KDoc stub for the Kotlin function under the cursor |
 | `:DroidExportWorkspace` | Export workspace config to JSON (Kotlin only) |
 | `:DroidCleanWorkspace` | Stop all LSPs and clean cached workspaces |
 | `:DroidLspStop` | Stop all LSP servers |

--- a/after/ftplugin/kotlin.lua
+++ b/after/ftplugin/kotlin.lua
@@ -1,0 +1,16 @@
+-- Kotlin editor experience: restore Neovim's built-in Kotlin indenter when a
+-- plugin (e.g. nvim-treesitter's unmaintained indent module) has overridden
+-- `indentexpr`. Opt-out via `cfg.editor.indent = false`.
+
+local ok, config = pcall(require, "droid.config")
+local editor = (ok and config.get().editor) or {}
+
+if editor.indent ~= false then
+    local buf = vim.api.nvim_get_current_buf()
+    -- Defer so we run AFTER other FileType autocmds (notably nvim-treesitter's
+    -- indent module) that set `indentexpr` last — otherwise they win and the
+    -- restore is a no-op. Scheduling runs once the FileType dispatch settles.
+    vim.schedule(function()
+        require("droid.kotlin.indent").restore(buf)
+    end)
+end

--- a/lua/droid/config.lua
+++ b/lua/droid/config.lua
@@ -79,6 +79,12 @@ local defaults = {
     -- :DroidInstall stays on the gradle path either way (android run
     -- cannot install without launching).
     android_cli = "auto",
+    -- Editor-experience features for Kotlin buffers. Independent of `lsp`.
+    editor = {
+        indent = true, -- restore Neovim's built-in GetKotlinIndent() when a plugin (e.g. treesitter indent) has overridden it
+        file_templates = true, -- offer templates when creating a new .kt file
+        templates = {}, -- user template map merged over defaults: { ["Name"] = "body" }
+    },
 }
 
 M.config = vim.deepcopy(defaults)

--- a/lua/droid/init.lua
+++ b/lua/droid/init.lua
@@ -10,6 +10,7 @@ function M.setup(opts)
     config.setup(opts)
     commands.setup_commands()
     lsp.setup()
+    require("droid.kotlin").setup(config.get())
 end
 
 M.build_and_run = actions.build_and_run

--- a/lua/droid/kotlin/indent.lua
+++ b/lua/droid/kotlin/indent.lua
@@ -1,0 +1,34 @@
+--- Kotlin indentation for droid.nvim.
+--- Neovim ships a maintained `indent/kotlin.vim` (`GetKotlinIndent()`); the
+--- common "Enter lands at column 0" problem is another plugin (typically
+--- nvim-treesitter's unmaintained indent module) overriding `indentexpr`. We do
+--- NOT hand-roll an indenter — we restore Neovim's built-in when it was
+--- overridden or unset.
+
+local M = {}
+
+--- Restore `GetKotlinIndent()` on `bufnr` if its `indentexpr` was overridden or
+--- is empty. Returns true if it changed the option, false otherwise.
+---@param bufnr integer|nil
+---@return boolean
+function M.restore(bufnr)
+    bufnr = bufnr or 0
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return false
+    end
+    if vim.bo[bufnr].indentexpr == "GetKotlinIndent()" then
+        return false
+    end
+    if vim.fn.exists("*GetKotlinIndent") == 0 then
+        -- Ensure the built-in function is defined (loads Neovim's indent script).
+        vim.cmd("runtime! indent/kotlin.vim")
+    end
+    if vim.fn.exists("*GetKotlinIndent") == 1 then
+        vim.bo[bufnr].indentexpr = "GetKotlinIndent()"
+        vim.bo[bufnr].indentkeys = "0},0),!^F,o,O,e,<CR>"
+        return true
+    end
+    return false
+end
+
+return M

--- a/lua/droid/kotlin/init.lua
+++ b/lua/droid/kotlin/init.lua
@@ -1,0 +1,28 @@
+--- Wiring for Kotlin editor-experience features: the :DroidKdoc command and
+--- the new-file template autocmd. Indentation is handled by
+--- after/ftplugin/kotlin.lua (restores Neovim's built-in GetKotlinIndent) and
+--- needs no setup.
+
+local M = {}
+
+---@param cfg table full plugin config
+function M.setup(cfg)
+    local editor = (cfg and cfg.editor) or {}
+
+    vim.api.nvim_create_user_command("DroidKdoc", function()
+        require("droid.kotlin.kdoc").generate()
+    end, { desc = "Generate a KDoc stub for the Kotlin function under the cursor" })
+
+    if editor.file_templates ~= false then
+        local grp = vim.api.nvim_create_augroup("DroidKotlinTemplates", { clear = true })
+        vim.api.nvim_create_autocmd("BufNewFile", {
+            group = grp,
+            pattern = "*.kt",
+            callback = function(ev)
+                require("droid.kotlin.templates").on_new_file(ev.buf)
+            end,
+        })
+    end
+end
+
+return M

--- a/lua/droid/kotlin/kdoc.lua
+++ b/lua/droid/kotlin/kdoc.lua
@@ -1,0 +1,127 @@
+--- KDoc stub generation for droid.nvim. Pure builders + a best-effort
+--- signature parser (multi-line paren-scan, sharpened by treesitter when the
+--- kotlin parser is present). Degrades to an empty KDoc rather than failing.
+
+local M = {}
+
+--- Build KDoc lines for a signature.
+---@param sig { name?:string, params?:string[], has_return?:boolean }
+---@param indent string leading whitespace to prepend to each line
+---@return string[]
+function M.build(sig, indent)
+    indent = indent or ""
+    local lines = { indent .. "/**", indent .. " * " }
+    for _, p in ipairs(sig.params or {}) do
+        lines[#lines + 1] = indent .. " * @param " .. p
+    end
+    if sig.has_return then
+        lines[#lines + 1] = indent .. " * @return"
+    end
+    lines[#lines + 1] = indent .. " */"
+    return lines
+end
+
+--- Parse a Kotlin function signature out of a (possibly multi-line) string.
+---@param text string
+---@return { name:string, params:string[], has_return:boolean }|nil
+function M._parse_signature_text(text)
+    text = text:gsub("%s+", " ")
+    local name, paramstr = text:match("fun%s+`?([%w_]+)`?%s*%((.-)%)")
+    if not name then
+        return nil
+    end
+    local params = {}
+    for _, seg in ipairs(vim.split(paramstr, ",", { plain = true })) do
+        local pname = seg:match("([%w_]+)%s*:")
+        if pname then
+            params[#params + 1] = pname
+        end
+    end
+    local has_return = text:match("%)%s*:%s*[%w_]") ~= nil
+    return { name = name, params = params, has_return = has_return }
+end
+
+--- Gather the signature text starting at a `fun` line until parens balance.
+---@param bufnr integer
+---@param fn_lnum integer 1-based line of the `fun`
+---@return string
+local function gather_signature(bufnr, fn_lnum)
+    local total = vim.api.nvim_buf_line_count(bufnr)
+    local depth, parts = 0, {}
+    for i = fn_lnum, math.min(fn_lnum + 20, total) do
+        local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1] or ""
+        parts[#parts + 1] = line
+        for ch in line:gmatch("[%(%)]") do
+            depth = depth + (ch == "(" and 1 or -1)
+        end
+        if i > fn_lnum and depth <= 0 then
+            break
+        end
+        if line:find("%)") and depth <= 0 then
+            break
+        end
+    end
+    return table.concat(parts, " ")
+end
+
+--- Resolve the signature at/after `lnum`. Returns (sig|nil, fn_lnum|nil).
+---@param bufnr integer
+---@param lnum integer 1-based cursor line
+function M.signature(bufnr, lnum)
+    local total = vim.api.nvim_buf_line_count(bufnr)
+    local fn_lnum
+    for i = lnum, math.min(lnum + 20, total) do
+        local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1] or ""
+        -- Skip comment lines so `fun` inside a `//` or ` * ` comment is ignored.
+        local is_comment = line:match("^%s*//") or line:match("^%s*%*")
+        if not is_comment and line:match("%f[%w]fun%f[%W]") then
+            fn_lnum = i
+            break
+        end
+    end
+    if not fn_lnum then
+        return nil, nil
+    end
+    -- Sharpen boundaries with treesitter when available; else paren-scan.
+    -- vibekit: TS path only refines node text; upgrade to a real query if the
+    -- kotlin grammar ever needs finer extraction.
+    local text = gather_signature(bufnr, fn_lnum)
+    local tsok, parser = pcall(vim.treesitter.get_parser, bufnr, "kotlin")
+    if tsok and parser then
+        local ptree = parser:parse()[1]
+        if ptree then
+            local node = ptree:root():named_descendant_for_range(fn_lnum - 1, 0, fn_lnum - 1, 0)
+            while node and node:type() ~= "function_declaration" do
+                node = node:parent()
+            end
+            if node then
+                text = vim.treesitter.get_node_text(node, bufnr)
+            end
+        end
+    end
+    return M._parse_signature_text(text), fn_lnum
+end
+
+--- Insert a KDoc block above the function at/after the cursor.
+function M.generate()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local lnum = vim.api.nvim_win_get_cursor(0)[1]
+    local sig, fn_lnum = M.signature(bufnr, lnum)
+    if not fn_lnum then
+        vim.notify("droid.nvim: no Kotlin function found at/after the cursor", vim.log.levels.WARN)
+        return
+    end
+    local fn_line = vim.api.nvim_buf_get_lines(bufnr, fn_lnum - 1, fn_lnum, false)[1] or ""
+    local indent = fn_line:match("^%s*") or ""
+    local doc
+    if sig then
+        doc = M.build(sig, indent)
+    else
+        doc = { indent .. "/**", indent .. " * ", indent .. " */" }
+        vim.notify("droid.nvim: could not resolve signature; inserted empty KDoc", vim.log.levels.INFO)
+    end
+    vim.api.nvim_buf_set_lines(bufnr, fn_lnum - 1, fn_lnum - 1, false, doc)
+    pcall(vim.api.nvim_win_set_cursor, 0, { fn_lnum + 1, #indent + 3 })
+end
+
+return M

--- a/lua/droid/kotlin/templates.lua
+++ b/lua/droid/kotlin/templates.lua
@@ -1,0 +1,110 @@
+--- New-file templates for Kotlin, interpolated by the server
+--- (`interpolateFileTemplate`). Ships defaults; users extend via
+--- `cfg.editor.templates`. A single `|` in a body marks the caret.
+
+local M = {}
+
+--- Built-in template bodies. `${PACKAGE_NAME}` / `${NAME}` are interpolated by
+--- the server; `|` marks the caret position.
+M.defaults = {
+    ["Class"] = "package ${PACKAGE_NAME}\n\nclass ${NAME} {\n    |\n}\n",
+    ["Interface"] = "package ${PACKAGE_NAME}\n\ninterface ${NAME} {\n    |\n}\n",
+    ["Data class"] = "package ${PACKAGE_NAME}\n\ndata class ${NAME}(|)\n",
+    ["Object"] = "package ${PACKAGE_NAME}\n\nobject ${NAME} {\n    |\n}\n",
+    ["Enum"] = "package ${PACKAGE_NAME}\n\nenum class ${NAME} {\n    |\n}\n",
+    ["Sealed class"] = "package ${PACKAGE_NAME}\n\nsealed class ${NAME} {\n    |\n}\n",
+}
+
+--- Merge user templates over defaults; return sorted names + the merged map.
+---@param user table<string,string>|nil
+---@return string[] names, table<string,string> map
+function M.list(user)
+    local map = vim.tbl_extend("force", {}, M.defaults, user or {})
+    local names = vim.tbl_keys(map)
+    table.sort(names)
+    return names, map
+end
+
+--- Split a template body on its first `|` caret marker.
+---@param text string
+---@return string text_without_marker, integer[]|nil cursor {row0, col0}
+function M.split_caret(text)
+    local lines = vim.split(text, "\n", { plain = true })
+    for i, line in ipairs(lines) do
+        local col = line:find("|", 1, true)
+        if col then
+            lines[i] = line:sub(1, col - 1) .. line:sub(col + 1)
+            return table.concat(lines, "\n"), { i - 1, col - 1 }
+        end
+    end
+    return text, nil
+end
+
+--- True while the buffer is still an untouched, empty new file.
+---@param bufnr integer
+---@return boolean
+local function still_empty(bufnr)
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return false
+    end
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    return not (#lines > 1 or (lines[1] and lines[1] ~= ""))
+end
+
+--- Offer the template picker and apply the chosen (server-interpolated) body.
+---@param bufnr integer
+---@param client vim.lsp.Client
+local function offer(bufnr, client)
+    local names, map = M.list(require("droid.config").get().editor.templates)
+    vim.ui.select(names, { prompt = "Kotlin file template" }, function(choice)
+            if not choice then
+                return
+            end
+            local uri = vim.uri_from_bufnr(bufnr)
+            client:request("workspace/executeCommand", {
+                command = "interpolateFileTemplate",
+                arguments = { uri, map[choice] },
+            }, function(err, result)
+                vim.schedule(function()
+                    if err or type(result) ~= "string" then
+                        vim.notify(
+                            "droid.nvim: file template unavailable: " .. tostring(err),
+                            vim.log.levels.WARN
+                        )
+                        return
+                    end
+                    local text, cursor = M.split_caret(result)
+                    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(text, "\n", { plain = true }))
+                    if cursor then
+                        pcall(vim.api.nvim_win_set_cursor, 0, { cursor[1] + 1, cursor[2] })
+                    end
+                end)
+            end, bufnr)
+    end)
+end
+
+--- BufNewFile handler: offer a template for an empty new .kt file. The LSP
+--- attaches asynchronously, so poll briefly for the kotlin_ls client (it is
+--- needed to interpolate the template) before giving up.
+---@param bufnr integer
+function M.on_new_file(bufnr)
+    local attempts = 0
+    local function try()
+        if not still_empty(bufnr) then
+            return
+        end
+        local client = require("droid.lsp.client").kotlin { bufnr = bufnr }
+        if client then
+            offer(bufnr, client)
+            return
+        end
+        attempts = attempts + 1
+        if attempts >= 15 then -- ~3s for kotlin_ls to attach, then give up
+            return
+        end
+        vim.defer_fn(try, 200)
+    end
+    vim.schedule(try)
+end
+
+return M


### PR DESCRIPTION
## Summary
Three dependency-free Kotlin editor quality-of-life features, under a new opt-out `cfg.editor` group.

## Changes
- **Indentation** — droid does not ship its own indenter. Neovim already bundles `indent/kotlin.vim` (`GetKotlinIndent`); the common "Enter → column 0" bug is another plugin (typically nvim-treesitter's unmaintained indent module) overriding `indentexpr`. `after/ftplugin/kotlin.lua` **restores `GetKotlinIndent()`**, deferred via `vim.schedule` so it runs after other `FileType` autocmds and actually wins. Opt-out `cfg.editor.indent = false`.
- **`:DroidKdoc`** — generate a `/** @param/@return */` stub for the Kotlin function under the cursor. Uses `vim.treesitter` (core) when the kotlin parser is present, falls back to a regex signature parser, and inserts an empty skeleton otherwise. Skips `fun` inside comments.
- **File templates** — a new empty `.kt` offers Class/Interface/Data class/Object/Enum/Sealed class scaffolds, interpolated by the server (`interpolateFileTemplate`); user-extendable via `cfg.editor.templates`. Polls briefly for `kotlin_ls` to attach. Opt-out `cfg.editor.file_templates = false`.

## Config
```lua
editor = {
  indent = true,          -- restore Neovim's built-in Kotlin indenter when overridden
  file_templates = true,  -- offer scaffolds for a new empty .kt
  templates = {},         -- extra templates merged over the built-ins
}
```

## Testing
Headless `nvim` checks pass: indent restore wins over a treesitter-style `FileType` override (and no-ops when already correct); opt-out respected; `kdoc.build`/`_parse_signature_text`/`generate` produce correct output incl. comment-skip; `templates.split_caret`/`list` merge; config defaults; `:DroidKdoc` + `BufNewFile` autocmd wired; whole-plugin load. No hard plugin dependencies (grep-verified).

⚠️ **Not verified here (needs a live kotlin-lsp + real project):** `:DroidKdoc` end-to-end against a running server's treesitter, and template insertion via `interpolateFileTemplate`. Manual smoke test pending.

## Notes
- The design changed mid-work: the original plan hand-rolled an indenter before we found Neovim already ships a maintained one — hence "restore" rather than "replace", and the redundant KDoc-continuation unit was dropped (Neovim's bundled ftplugin already does it).
