### PR TITLE
fix(gradle): empty string args make gradle fail

### DIFF
--- a/lua/droid/gradle.lua
+++ b/lua/droid/gradle.lua
@@ -71,10 +71,15 @@ function M.find_gradlew()
 end
 
 local function run_gradle_task(cwd, gradlew, task, args, callback)
+    local cmd_args = { gradlew, task }
+    if args and args ~= '' then
+        table.insert(cmd_args, args)
+    end
+
     -- List form so paths with separators/spaces are passed verbatim to the
     -- PTY rather than through a shell that may mis-parse them (notably the
     -- forward-slash gradlew.bat path on Windows cmd.exe).
-    local cmd = vim.iter({ gradlew, task, args or {} }):flatten():totable()
+    local cmd = vim.iter(cmd_args):flatten():totable()
 
     local buf, win = buffer.get_or_create("gradle", "horizontal")
 


### PR DESCRIPTION
If an empty string is passed to gradlew, it complains with this error:
"Cannot locate matching tasks for an empty path. The path should include a task name (for example ':help' or 'help')."

This issue showed up while trying to run the tests with `:DroidTask test`