### PR TITLE
fix(lsp): stop blaming the install for a missing reload handler

### DIFF
--- a/lua/droid/lsp/kotlin/init.lua
+++ b/lua/droid/lsp/kotlin/init.lua
@@ -177,14 +177,15 @@ end
 --- Build the initializationOptions table for kotlin_ls.
 --- The server uses `defaultSdk` (see reference client lspClient.ts); an earlier
 --- `defaultJdk` key was silently ignored.
+--- Returns an empty *dict*, not an empty table: `vim.json.encode {}` produces
+--- `[]`, and the server logs `"initializationOptions": []` for it.
 ---@param kotlin_cfg table
 ---@return table
 function M._init_options(kotlin_cfg)
-    local init_opts = {}
-    if kotlin_cfg.jdk_for_symbol_resolution then
-        init_opts.defaultSdk = kotlin_cfg.jdk_for_symbol_resolution
+    if not kotlin_cfg.jdk_for_symbol_resolution then
+        return vim.empty_dict()
     end
-    return init_opts
+    return { defaultSdk = kotlin_cfg.jdk_for_symbol_resolution }
 end
 
 --- Filetypes kotlin_ls attaches to. Java is opt-in: attaching keeps Kotlin's

--- a/lua/droid/lsp/kotlin/sync.lua
+++ b/lua/droid/lsp/kotlin/sync.lua
@@ -126,6 +126,9 @@ end
 
 -- Set once the server reports it has no handler for intellij/reloadWorkspace, so
 -- we stop retrying (and stop erroring) on every subsequent save this session.
+-- The released standalone kotlin-lsp (checked against 262.9593.0) has no such
+-- handler even though the reference VS Code client already sends the request,
+-- so this path is the norm, not a sign of an outdated install.
 local reload_unsupported = false
 
 --- Send `intellij/reloadWorkspace`. Progress/failure streams back via importLog.
@@ -136,7 +139,10 @@ function M.reload(opts)
     opts = opts or {}
     if reload_unsupported then
         if not opts.silent then
-            vim.notify("droid.nvim: this kotlin-lsp build does not support workspace reload", vim.log.levels.WARN)
+            vim.notify(
+                "droid.nvim: this kotlin-lsp build has no intellij/reloadWorkspace handler - use :DroidLspRestart to pick up build-file changes",
+                vim.log.levels.WARN
+            )
         end
         return
     end
@@ -154,14 +160,16 @@ function M.reload(opts)
         end
         vim.schedule(function()
             local msg = (type(err) == "table" and err.message) or tostring(err)
-            -- Older kotlin-lsp builds have no handler for this request; degrade
-            -- gracefully instead of erroring on every save.
+            -- The server has no handler for this request; degrade gracefully
+            -- instead of erroring on every save. 262.9593.0 answers -32803
+            -- (RequestFailed) rather than MethodNotFound, which a real reload
+            -- failure also uses, so only the message can tell them apart.
             local unsupported = (type(err) == "table" and err.code == -32601)
                 or (msg and msg:find("no handler for request", 1, true) ~= nil)
             if unsupported then
                 reload_unsupported = true
                 vim.notify(
-                    "droid.nvim: kotlin-lsp does not support workspace reload; auto-reload disabled for this session (update kotlin-lsp to enable it)",
+                    "droid.nvim: kotlin-lsp has no intellij/reloadWorkspace handler; auto-reload disabled for this session - use :DroidLspRestart after changing build files",
                     vim.log.levels.WARN
                 )
             else


### PR DESCRIPTION
## Problem

Saving a build file printed:

> droid.nvim: kotlin-lsp does not support workspace reload; auto-reload disabled for this session (update kotlin-lsp to enable it)

on an install that was already on the newest release. The advice was wrong: there is no version to update to.

## What is actually happening

The server log tells the real story:

```
SEVERE - #c.j.l.i.LspClient -
java.lang.IllegalArgumentException: no handler for request: intellij/reloadWorkspace
	at com.jetbrains.lsp.implementation.WithLspKt$withLspImpl$2$1$1$1$1.invokeSuspend(withLsp.kt:141)
```

Confirmed by driving the installed `kotlin-server-262.9593.0` directly over stdio: after a successful Gradle import it answers

```
{"id": 99, "error": {"code": -32803, "message": "no handler for request: intellij/reloadWorkspace"}}
```

`WorkspaceImportLanguageServerExtension` loads, but its only exposed command is `exportWorkspace`. Setting `initializationOptions.intellijExtensions: true`, which the reference VS Code client sends and droid does not, changes nothing: that flag was set for the run that produced the response above. The reference client in `external/kotlin-lsp` sends the request, but that source is ahead of the shipped server build.

## Changes

**`sync.lua`** - both notifications name the missing handler and point at `:DroidLspRestart` as the way to pick up build-file changes, instead of telling the user to update. The detection comment now records that the server answers `-32803` rather than `MethodNotFound`, which a genuine reload failure also uses, so only the message string can tell the two apart. Detection itself is unchanged, deliberately: matching `-32803` by code would disable auto-reload on a real failure.

**`init.lua`** - a separate bug found on the way. `_init_options` returned `{}`, and `vim.json.encode {}` produces `[]`, so every session sent `"initializationOptions": []`. The server log confirms it read the array form on every start. Now returns `vim.empty_dict()`.

## Effect

Auto-reload still degrades, since nothing here can add a handler to the server, but it no longer misdiagnoses the user's install.
